### PR TITLE
Fix login route struct import

### DIFF
--- a/backend/src/api/login.rs
+++ b/backend/src/api/login.rs
@@ -2,7 +2,6 @@ use http::Request;
 use http::Response;
 use http::StatusCode;
 use std::error::Error;
-use crate::api::login;
 use crate::not_found_route;
 
 use crate::{PlatformStore, PlatformModel};
@@ -17,7 +16,7 @@ pub fn login_route(
   let user = platform_store.borrow_inner()
     .query_owned(format!("user-{}", email.clone()))?;
 
-  let login_attempt = login::LoginAttempt {
+  let login_attempt = LoginAttempt {
     email,
     password,
   };


### PR DESCRIPTION
## Summary
- fix path for `LoginAttempt` in login route

## Testing
- `cargo check --workspace --locked --offline` *(fails: no matching package named `log` found)*

------
https://chatgpt.com/codex/tasks/task_e_687ec2bf8264832ba6046c7fa084d2a1