### PR TITLE
Fix compile with nightly toolchain

### DIFF
--- a/backend/src/api/login.rs
+++ b/backend/src/api/login.rs
@@ -2,7 +2,6 @@ use http::Request;
 use http::Response;
 use http::StatusCode;
 use std::error::Error;
-use crate::api::login;
 use crate::not_found_route;
 
 use crate::{PlatformStore, PlatformModel};
@@ -17,7 +16,7 @@ pub fn login_route(
   let user = platform_store.borrow_inner()
     .query_owned(format!("user-{}", email.clone()))?;
 
-  let login_attempt = login::LoginAttempt {
+  let login_attempt = LoginAttempt {
     email,
     password,
   };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt"]
+
+[build]
+target = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
## Summary
- fix path for `LoginAttempt` in login route
- add rust-toolchain file to use nightly compiler

## Testing
- `rustup run nightly cargo check --workspace --locked --offline`


------
https://chatgpt.com/codex/tasks/task_e_687ec2bf8264832ba6046c7fa084d2a1