### PR TITLE
Fix login attempt instantiation

### DIFF
--- a/backend/src/api/login.rs
+++ b/backend/src/api/login.rs
@@ -2,7 +2,6 @@ use http::Request;
 use http::Response;
 use http::StatusCode;
 use std::error::Error;
-use crate::api::login;
 use crate::not_found_route;
 
 use crate::{PlatformStore, PlatformModel};
@@ -17,7 +16,7 @@ pub fn login_route(
   let user = platform_store.borrow_inner()
     .query_owned(format!("user-{}", email.clone()))?;
 
-  let login_attempt = login::LoginAttempt {
+  let login_attempt = models::LoginAttempt {
     email,
     password,
   };


### PR DESCRIPTION
## Summary
- remove unused `crate::api::login` import
- instantiate login attempts using `models::LoginAttempt`

## Testing
- `RUSTC_BOOTSTRAP=1 cargo check`

------
https://chatgpt.com/codex/tasks/task_e_687ec518b61c832bb710490bae919308