### PR TITLE
Add password utils tests

### DIFF
--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -9,4 +9,4 @@ rkyv = { version = "0.8.10", features = ["bytecheck", "alloc"] }
 rkyv_derive = "0.8.10"
 serde = { version = "1.0", features = ["derive"] }
 argon2 = "0.5"
-rand_core = "0.6"
+rand_core = { version = "0.6", features = ["getrandom"] }

--- a/models/src/utils.rs
+++ b/models/src/utils.rs
@@ -28,3 +28,24 @@ pub fn verify_password(password: &str, hash: &str) -> bool {
     false
   }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{hash_password, verify_password};
+
+    #[test]
+    fn hash_password_changes_input() {
+        let password = "hunter2";
+        let hashed = hash_password(password);
+        assert_ne!(password, hashed, "hashed password should differ from input");
+    }
+
+    #[test]
+    fn verify_password_checks_correctness() {
+        let password = "correcthorsebatterystaple";
+        let hashed = hash_password(password);
+
+        assert!(verify_password(password, &hashed));
+        assert!(!verify_password("wrong-password", &hashed));
+    }
+}


### PR DESCRIPTION
## Summary
- enable `getrandom` feature of `rand_core`
- test the hash and verify helpers in `utils.rs`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687ec639d304832bb9d30e9fe7f3d728