### PR TITLE
Fix announcement field typo

### DIFF
--- a/backend/src/api/dashboard_route.rs
+++ b/backend/src/api/dashboard_route.rs
@@ -10,7 +10,7 @@ use models::{Event};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DashboardApi {
-  pub announcment: String,
+  pub announcement: String,
   pub name: String,
   pub events: Vec<Event>,
 }
@@ -40,7 +40,7 @@ pub fn dashboard_route(
 
   /*let dummy_data = DashboardApi {
     name: "Bucket Golf Leagues".to_string(),
-    announcment: "⛳️ New summer leagues of bucket golf just dropped. Rally your crew and start swinging!".to_string(),
+    announcement: "⛳️ New summer leagues of bucket golf just dropped. Rally your crew and start swinging!".to_string(),
     events,
   };*/
 


### PR DESCRIPTION
## Summary
- fix spelling of `announcement` field in dashboard API
- update example comment to use new field name
- verify build with nightly toolchain

## Testing
- `cargo +nightly check > /tmp/out.txt 2>&1 && tail -n 20 /tmp/out.txt`

------
https://chatgpt.com/codex/tasks/task_e_687ec624f144832bb2c80996eb45e40c