### PR TITLE
Fix wasm compatibility in models crate

### DIFF
--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -8,5 +8,7 @@ edition = "2021"
 rkyv = { version = "0.8.10", features = ["bytecheck", "alloc"] }
 rkyv_derive = "0.8.10"
 serde = { version = "1.0", features = ["derive"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 argon2 = "0.5"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/models/src/utils.rs
+++ b/models/src/utils.rs
@@ -29,7 +29,7 @@ pub fn verify_password(password: &str, hash: &str) -> bool {
   }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::{hash_password, verify_password};
 


### PR DESCRIPTION
## Summary
- gate `argon2` and `rand_core` deps behind `cfg(not(target_arch = "wasm32"))`
- disable password unit tests when building for wasm

## Testing
- `cargo test`
- `cargo build -p models --target wasm32-unknown-unknown`

------
https://chatgpt.com/codex/tasks/task_e_687eca0818b8832b890ac04f4e34b82b