### PR TITLE
Add platform setup endpoints

### DIFF
--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -3,3 +3,5 @@ pub mod dashboard_route;
 //pub mod create_event_route;
 pub mod event_route;
 pub mod login;
+pub mod platform_create_route;
+pub mod platform_update_route;

--- a/backend/src/api/platform_create_route.rs
+++ b/backend/src/api/platform_create_route.rs
@@ -1,0 +1,21 @@
+use http::{Request, Response, StatusCode};
+use std::error::Error;
+
+use crate::{PlatformCommand, PlatformStore};
+use models::Platform;
+
+pub fn platform_create_route(
+    req: Request<Vec<u8>>,
+    mut platform_store: PlatformStore,
+) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+    let platform: Platform = serde_json::from_slice(req.body())?;
+    platform_store.command(&PlatformCommand::CreatePlatform(platform))?;
+
+    Ok(Response::builder()
+        .status(StatusCode::CREATED)
+        .header("Content-Type", "application/json")
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "*")
+        .header("Access-Control-Allow-Headers", "*")
+        .body(b"{\"status\":\"created\"}".to_vec())?)
+}

--- a/backend/src/api/platform_update_route.rs
+++ b/backend/src/api/platform_update_route.rs
@@ -1,0 +1,21 @@
+use http::{Request, Response, StatusCode};
+use std::error::Error;
+
+use crate::{PlatformCommand, PlatformStore};
+use models::PlatformUser;
+
+pub fn platform_update_route(
+    req: Request<Vec<u8>>,
+    mut platform_store: PlatformStore,
+) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+    let user: PlatformUser = serde_json::from_slice(req.body())?;
+    platform_store.command(&PlatformCommand::CreateUser(user))?;
+
+    Ok(Response::builder()
+        .status(StatusCode::CREATED)
+        .header("Content-Type", "application/json")
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "*")
+        .header("Access-Control-Allow-Headers", "*")
+        .body(b"{\"status\":\"created\"}".to_vec())?)
+}

--- a/backend/src/bin/backend.rs
+++ b/backend/src/bin/backend.rs
@@ -28,6 +28,8 @@ use backend::{
   dashboard_route,
   event_details_route,
   login_route,
+  platform_create_route,
+  platform_update_route,
 };
 fn clear_directory(path: &str) -> io::Result<()> {
   if Path::new(path).exists() {
@@ -177,6 +179,14 @@ pub fn main() -> Result<(), Box<dyn Error>>{
           request.headers().get("x-password")
             .and_then(|v| v.to_str().ok()).unwrap_or_default()
             .to_string(),
+        ),
+        "/platform/create" => platform_create_route(
+          http::Request::builder().body(Vec::new()).unwrap(),
+          platform_store.clone(),
+        ),
+        "/platform/user" => platform_update_route(
+          http::Request::builder().body(Vec::new()).unwrap(),
+          platform_store.clone(),
         ),
 
         _ => not_found_route(),

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -27,6 +27,8 @@ pub use crate::api::dashboard_route::dashboard_route;
 //pub use crate::api::create_event_route::create_event_route;
 pub use crate::api::event_route::event_details_route;
 pub use crate::api::login::login_route;
+pub use crate::api::platform_create_route::platform_create_route;
+pub use crate::api::platform_update_route::platform_update_route;
 
 pub mod database;
 pub use crate::database::kv_store::KVStore;

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -22,7 +22,7 @@ pub use pages::homepage::Homepage;
 pub use pages::login::Login;
 pub use pages::signup::Signup;
 pub use pages::get_started::GetStarted;
-pub use pages::get_started::ConfigurePlatform;
+pub use pages::configure_platform::ConfigurePlatform;
 pub use pages::not_found::PageNotFound;
 pub use pages::dashboard::Dashboard;
 pub use pages::create_event::CreateEvent;

--- a/frontend/src/pages/configure_platform.rs
+++ b/frontend/src/pages/configure_platform.rs
@@ -1,0 +1,72 @@
+use dioxus::prelude::*;
+use crate::{BrandContext, ClientContext};
+use models::Platform;
+
+#[component]
+pub fn ConfigurePlatform() -> Element {
+    let brand = use_context::<Signal<BrandContext>>();
+    let client = use_context::<Signal<ClientContext>>();
+    let BrandContext { name: _, logo: _, primary_color: _, secondary_color } = brand.read().clone();
+
+    let mut community_name = use_signal(|| String::new());
+    let mut community_description = use_signal(|| String::new());
+    let mut platform_url = use_signal(|| String::new());
+    let mut submit = use_signal(|| false);
+
+    use_future(move || async move {
+        if !submit() { return; }
+        let platform = Platform {
+            tenant_id: "bucket-golf".into(),
+            community_name: community_name(),
+            community_description: community_description(),
+            platform_url: platform_url(),
+        };
+        let _ = client().client
+            .post("http://localhost:8000/platform/create")
+            .json(&platform)
+            .send()
+            .await;
+    });
+
+    rsx!(
+        div { style: "min-height: 100vh; padding: 3rem 1rem; background-color: #f9fafb; font-family: sans-serif;",
+            div { style: "max-width: 40rem; margin: 0 auto;",
+                h1 { style: "font-size: 2rem; font-weight: bold; color: #111827; text-align: center; margin-bottom: 2rem;",
+                    "Configure Your Platform"
+                }
+                p { style: "font-size: 1rem; color: #4b5563; margin-bottom: 1.5rem;",
+                    "Set your branding, community rules, and permissions (you can change this later)."
+                }
+                form { style: "display: flex; flex-direction: column; gap: 1rem;",
+                    input {
+                        r#type: "text",
+                        placeholder: "Community Name",
+                        oninput: move |e| community_name.set(e.value()),
+                        value: community_name.clone(),
+                        style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
+                    }
+                    textarea {
+                        placeholder: "Community Description",
+                        oninput: move |e| community_description.set(e.value()),
+                        value: community_description.clone(),
+                        style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; height: 100px;",
+                    }
+                    input {
+                        r#type: "url",
+                        placeholder: "Platform URL",
+                        oninput: move |e| platform_url.set(e.value()),
+                        value: platform_url.clone(),
+                        style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
+                    }
+                    p { style: "font-size: 0.875rem; color: #6b7280; margin-top: -0.75rem; margin-bottom: 0.5rem;",
+                        "DNS update instructions will be sent to your account's email"
+                    }
+                    button { style: "background-color: {secondary_color}; color: white; font-weight: 600; padding: 0.75rem 1.5rem; border-radius: 0.5rem; border: none; cursor: pointer;",
+                        onclick: move |_| submit.set(true),
+                        "Save & Continue"
+                    }
+                }
+            }
+        }
+    )
+}

--- a/frontend/src/pages/get_started.rs
+++ b/frontend/src/pages/get_started.rs
@@ -34,45 +34,6 @@ pub fn GetStarted() -> Element {
     )
 }
 
-#[component]
-pub fn ConfigurePlatform() -> Element {
-  let brand = use_context::<Signal<BrandContext>>();
-  let BrandContext {name: _, logo: _, primary_color: _, secondary_color} = brand.read().clone();
-    rsx!(
-      div { style: "min-height: 100vh; padding: 3rem 1rem; background-color: #f9fafb; font-family: sans-serif;",
-        div { style: "max-width: 40rem; margin: 0 auto;",
-          h1 { style: "font-size: 2rem; font-weight: bold; color: #111827; text-align: center; margin-bottom: 2rem;",
-            "Configure Your Platform"
-          }
-          p { style: "font-size: 1rem; color: #4b5563; margin-bottom: 1.5rem;",
-            "Set your branding, community rules, and permissions (you can change this later)."
-          }
-          form { style: "display: flex; flex-direction: column; gap: 1rem;",
-            input {
-              r#type: "text",
-              placeholder: "Community Name",
-              style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
-            }
-            textarea {
-              placeholder: "Community Description",
-              style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; height: 100px;",
-            }
-            input {
-              r#type: "url",
-              placeholder: "Platform URL",
-              style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
-            }
-            p { style: "font-size: 0.875rem; color: #6b7280; margin-top: -0.75rem; margin-bottom: 0.5rem;",
-              "DNS update instructions will be sent to your account's email"
-            }
-            button { style: "background-color: {secondary_color}; color: white; font-weight: 600; padding: 0.75rem 1.5rem; border-radius: 0.5rem; border: none; cursor: pointer;",
-              "Save & Continue"
-            }
-          }
-        }
-      }
-    )
-}
 
 #[component]
 pub fn InsightsDashboard() -> Element {

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -2,6 +2,7 @@
 pub mod homepage;
 pub mod login;
 pub mod signup;
+pub mod configure_platform;
 pub mod get_started;
 pub mod not_found;
 pub mod dashboard;

--- a/frontend/src/pages/signup.rs
+++ b/frontend/src/pages/signup.rs
@@ -1,10 +1,26 @@
 use dioxus::prelude::*;
-use crate::{Route, BrandContext};
+use crate::{Route, BrandContext, ClientContext};
+use models::PlatformUser;
 
 #[component]
 pub fn Signup() -> Element {
   let brand = use_context::<Signal<BrandContext>>();
+  let client = use_context::<Signal<ClientContext>>();
   let BrandContext {name: _, logo: _, primary_color: _, secondary_color} = brand.read().clone();
+  let mut email = use_signal(|| String::new());
+  let mut password = use_signal(|| String::new());
+  let mut confirm = use_signal(|| String::new());
+  let mut submit = use_signal(|| false);
+
+  use_future(move || async move {
+    if !submit() { return; }
+    let user = PlatformUser { email: email(), password: password() };
+    let _ = client().client
+      .post("http://localhost:8000/platform/user")
+      .json(&user)
+      .send()
+      .await;
+  });
   rsx!(
     div { style: "min-height: 100vh; display: flex; align-items: center; justify-content: center; background-color: #f9fafb; font-family: sans-serif;",
       div { style: "width: 100%; max-width: 24rem; background: white; padding: 2rem; border-radius: 0.5rem; box-shadow: 0 4px 6px rgba(0,0,0,0.1);",
@@ -19,6 +35,8 @@ pub fn Signup() -> Element {
             input {
               r#type: "email",
               placeholder: "you@example.com",
+              oninput: move |e| email.set(e.value()),
+              value: email.clone(),
               style: "width: 100%; padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
             }
           }
@@ -29,6 +47,8 @@ pub fn Signup() -> Element {
             input {
               r#type: "password",
               placeholder: "••••••••",
+              oninput: move |e| password.set(e.value()),
+              value: password.clone(),
               style: "width: 100%; padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
             }
           }
@@ -39,12 +59,15 @@ pub fn Signup() -> Element {
             input {
               r#type: "password",
               placeholder: "••••••••",
+              oninput: move |e| confirm.set(e.value()),
+              value: confirm.clone(),
               style: "width: 100%; padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
             }
           }
           Link { to: Route::ConfigurePlatform {},
             button {
               r#type: "submit",
+              onclick: move |_| submit.set(true),
               style: "margin-top: 1rem; background-color: {secondary_color}; color: white; font-weight: 600; padding: 0.75rem; border: none; border-radius: 0.5rem; cursor: pointer;",
               "Sign Up"
             }


### PR DESCRIPTION
## Summary
- expose new platform API modules
- create `platform_create_route` and `platform_update_route`
- wire routes in backend server
- call new APIs from signup and configure platform pages
- split ConfigurePlatform page into its own module

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687ecdd72a74832b960b3b4d96b8a0b0