### PR TITLE
Implement non-blocking read_line

### DIFF
--- a/backend/src/async/tcp_stream.rs
+++ b/backend/src/async/tcp_stream.rs
@@ -1,60 +1,65 @@
-use std::net::TcpStream;
 use std::io::BufReader;
 use std::io::Write;
+use std::net::TcpStream;
 use std::task::LocalWaker;
 use std::time::Duration;
 
-use crate::NetExecutor;
 use crate::AsyncReadLineFuture;
 use crate::AsyncWriteAllFuture;
+use crate::NetExecutor;
 
 #[allow(unused_imports)]
-use log::{error, warn, info, debug, trace};
+use log::{debug, error, info, trace, warn};
 
 pub struct AsyncTcpStream {
-  reader: BufReader<TcpStream>,
-  executor: NetExecutor,
+    reader: BufReader<TcpStream>,
+    executor: NetExecutor,
 }
 
 impl Drop for AsyncTcpStream {
-  fn drop(&mut self) {
-    self.executor.clone().unregister(self.reader.get_ref());
-  }
+    fn drop(&mut self) {
+        self.executor.clone().unregister(self.reader.get_ref());
+    }
 }
 
 impl AsyncTcpStream {
-  pub fn new(stream: TcpStream, executor: NetExecutor) -> Result<Self, Box<dyn std::error::Error>> {
-    trace!("Setting TcpStream to non-blocking");
-    stream.set_nonblocking(true)?;
-    let this = AsyncTcpStream {
-      reader: BufReader::new(stream),
-      executor: executor.clone()
-    };
-    executor.preregister(this.reader.get_ref());
-    Ok(this)
-  }
+    pub fn new(
+        stream: TcpStream,
+        executor: NetExecutor,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        trace!("Setting TcpStream to non-blocking");
+        stream.set_nonblocking(true)?;
+        let this = AsyncTcpStream {
+            reader: BufReader::new(stream),
+            executor: executor.clone(),
+        };
+        executor.preregister(this.reader.get_ref());
+        Ok(this)
+    }
 
-  pub fn set_timeout(&self, duration: Option<Duration>) {
-    self.executor.clone().set_timeout(self.reader.get_ref(), duration)
-  }
+    pub fn set_timeout(&self, duration: Option<Duration>) {
+        self.executor
+            .clone()
+            .set_timeout(self.reader.get_ref(), duration)
+    }
 
-  pub fn register(&self, waker: LocalWaker) {
-    self.executor.clone().register(self.reader.get_ref(), waker)
-  }
+    pub fn register(&self, waker: LocalWaker) {
+        self.executor.clone().register(self.reader.get_ref(), waker)
+    }
 
-  pub fn reader(&mut self) -> &mut BufReader<TcpStream> {
-    &mut self.reader
-  }
+    pub fn reader(&mut self) -> &mut BufReader<TcpStream> {
+        &mut self.reader
+    }
 
-  pub fn read_line(&mut self) -> AsyncReadLineFuture {
-    AsyncReadLineFuture::new(self)
-  }
+    pub fn read_line(&mut self) -> AsyncReadLineFuture<'_> {
+        AsyncReadLineFuture::new(self)
+    }
 
-  pub fn write(&self, buf: &[u8]) -> std::io::Result<usize> {
-    self.reader.get_ref().write(buf)
-  }
+    pub fn write(&self, buf: &[u8]) -> std::io::Result<usize> {
+        self.reader.get_ref().write(buf)
+    }
 
-  pub fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> AsyncWriteAllFuture<'a> {
-    AsyncWriteAllFuture::new(self, buf)
-  }
+    pub fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> AsyncWriteAllFuture<'a> {
+        AsyncWriteAllFuture::new(self, buf)
+    }
 }

--- a/backend/src/executor/net_executor.rs
+++ b/backend/src/executor/net_executor.rs
@@ -1,147 +1,223 @@
-use std::task::ContextBuilder;
-use std::time::Instant;
-use std::time::Duration;
-use std::task::LocalWaker;
-use std::cell::RefCell;
-use std::future::Future;
-use std::rc::Rc;
-use std::os::fd::AsRawFd;
-use std::task::Waker;
-use polling::{Event, Events, Poller};
-use polling::AsSource;
 use polling::AsRawSource;
+use polling::AsSource;
+use polling::{Event, Events, Poller};
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::future::Future;
+use std::os::fd::AsRawFd;
+use std::rc::Rc;
+use std::task::ContextBuilder;
+use std::task::LocalWaker;
+use std::task::Waker;
+use std::time::Duration;
+use std::time::Instant;
 
 #[allow(unused_imports)]
-use log::{error, warn, info, debug, trace};
+use log::{debug, error, info, trace, warn};
 
 use crate::NetTask;
 
 //#[derive(Default)]
 struct NetExecutorInner {
-  poller: Poller,
-  map: HashMap<usize, LocalWaker>,
-  queue: Vec<NetTask>,
-  timeouts: HashMap<usize, (Instant, Duration)>,
+    poller: Poller,
+    map: HashMap<usize, LocalWaker>,
+    queue: Vec<NetTask>,
+    timeouts: HashMap<usize, (Instant, Duration)>,
 }
 
 #[derive(Clone)]
 pub struct NetExecutor(Rc<RefCell<NetExecutorInner>>);
 
 impl Default for NetExecutor {
-  fn default() -> Self {
-    Self::new()
-  }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl NetExecutor {
-  pub fn new() -> Self {
-    NetExecutor(Rc::new(RefCell::new(NetExecutorInner {
-      poller: Poller::new().unwrap(),
-      map: HashMap::new(),
-      queue: Vec::new(),
-      timeouts: HashMap::new(),
-    })))
-  }
-
-  pub fn set_timeout(self, fd: impl AsSource, time: Option<Duration>) {
-    match time {
-      Some(d) => {
-        self.0.borrow_mut().timeouts.insert(fd.source().as_raw_fd().try_into().unwrap(), (Instant::now(), d));
-      },
-      None => {
-        self.0.borrow_mut().timeouts.remove(&fd.source().as_raw_fd().try_into().unwrap());
-      },
+    pub fn new() -> Self {
+        NetExecutor(Rc::new(RefCell::new(NetExecutorInner {
+            poller: Poller::new().unwrap(),
+            map: HashMap::new(),
+            queue: Vec::new(),
+            timeouts: HashMap::new(),
+        })))
     }
 
-  }
-
-  pub fn enqueue(self, task: NetTask) {
-    trace!("Queueing Task");
-    self.0.borrow_mut().queue.push(task);
-    trace!("Queued Task");
-  }
-
-  pub fn preregister(self, raw: impl AsRawSource) {
-    let fd: usize = raw.raw().try_into().unwrap();
-
-    unsafe {
-      self.0.borrow().poller.add(raw, Event::none(fd)).unwrap();
-      trace!("Added fd #{fd} to Poller");
-    }
-  }
-
-  pub fn unregister(self, raw: impl AsSource) {
-    let fd: usize = raw.source().as_raw_fd().try_into().unwrap();
-    trace!("Unregistering fd #{fd} from poller");
-    self.0.borrow().poller.delete(&raw).unwrap();
-    self.set_timeout(raw, None);
-  }
-
-  pub fn register(self, raw: impl AsSource, waker: LocalWaker) {
-    let fd: usize = raw.source().as_raw_fd().try_into().unwrap();
-    trace!("Registering fd #{fd} with NetExecutor");
-    self.0.borrow_mut().map.insert(fd, waker);
-    trace!("Added fd #{fd} to NetExecutor's Map");
-
-    self.0.borrow().poller.modify(raw, Event::readable(fd)).unwrap();
-    trace!("Added fd #{fd} to Poller");
-  }
-
-  pub fn spawn(self, future: impl Future<Output = ()> + 'static) {
-    let future = Box::pin(future);
-    trace!("Spawning task with NetExecutor");
-    let task = NetTask::new(future, self.clone());
-    self.enqueue(task);
-    trace!("Added task to NetExecutor's queue");
-  }
-
-  pub fn run(self) {
-    loop {
-      loop {
-        let mut queue = std::mem::take(&mut self.0.borrow_mut().queue);
-        let queue_size = queue.len();
-        if queue_size == 0 { break }
-
-        trace!("Starting NetExecutor loop with {queue_size} tasks");
-        for task in queue.drain(0..) {
-          let task: Rc<NetTask> = Rc::new(task);
-          let _ = unsafe { task.poll(&mut ContextBuilder::from_waker(Waker::noop())
-            .local_waker(&task.clone().into())
-            .build()) } ;
+    pub fn set_timeout(self, fd: impl AsSource, time: Option<Duration>) {
+        match time {
+            Some(d) => {
+                self.0.borrow_mut().timeouts.insert(
+                    fd.source().as_raw_fd().try_into().unwrap(),
+                    (Instant::now(), d),
+                );
+            }
+            None => {
+                self.0
+                    .borrow_mut()
+                    .timeouts
+                    .remove(&fd.source().as_raw_fd().try_into().unwrap());
+            }
         }
-      }
-
-      trace!("Polling");
-      let events = {
-        let mut events = Events::new();
-        self.0.borrow().poller.wait(&mut events, Some(Duration::new(100000, 0))).unwrap();
-        events
-      };
-      let events_len = events.len();
-      trace!("Recieved {events_len} events from Poller");
-      for event in events.iter() {
-        let fd = event.key;
-        trace!("Recieved an event from Poller {event:?}");
-        let waker = self.0.borrow_mut().map.remove(&fd).unwrap();
-        waker.wake();
-        trace!("Called wake on fd #{fd}");
-      }
-
-      trace!("Reviewing timeouts");
-      let timeouts = self.0.borrow().timeouts.iter()
-        .filter_map(|(k, (i, d))|
-          match i.elapsed() > *d {
-            true => Some(*k),
-            false => None,
-        })
-        .collect::<Vec<usize>>();
-
-      let timeouts_len = timeouts.len();
-      trace!("Timing out {timeouts_len} fds");
-      let _ = timeouts.iter()
-        .filter_map(|fd| self.0.borrow_mut().map.remove(fd))
-        .collect::<Vec<LocalWaker>>();
     }
-  }
+
+    pub fn enqueue(self, task: NetTask) {
+        trace!("Queueing Task");
+        self.0.borrow_mut().queue.push(task);
+        trace!("Queued Task");
+    }
+
+    pub fn preregister(self, raw: impl AsRawSource) {
+        let fd: usize = raw.raw().try_into().unwrap();
+
+        unsafe {
+            self.0.borrow().poller.add(raw, Event::none(fd)).unwrap();
+            trace!("Added fd #{fd} to Poller");
+        }
+    }
+
+    pub fn unregister(self, raw: impl AsSource) {
+        let fd: usize = raw.source().as_raw_fd().try_into().unwrap();
+        trace!("Unregistering fd #{fd} from poller");
+        self.0.borrow().poller.delete(&raw).unwrap();
+        self.set_timeout(raw, None);
+    }
+
+    pub fn register(self, raw: impl AsSource, waker: LocalWaker) {
+        let fd: usize = raw.source().as_raw_fd().try_into().unwrap();
+        trace!("Registering fd #{fd} with NetExecutor");
+        self.0.borrow_mut().map.insert(fd, waker);
+        trace!("Added fd #{fd} to NetExecutor's Map");
+
+        self.0
+            .borrow()
+            .poller
+            .modify(raw, Event::readable(fd))
+            .unwrap();
+        trace!("Added fd #{fd} to Poller");
+    }
+
+    pub fn spawn(self, future: impl Future<Output = ()> + 'static) {
+        let future = Box::pin(future);
+        trace!("Spawning task with NetExecutor");
+        let task = NetTask::new(future, self.clone());
+        self.enqueue(task);
+        trace!("Added task to NetExecutor's queue");
+    }
+
+    pub fn run(self) {
+        loop {
+            loop {
+                let mut queue = std::mem::take(&mut self.0.borrow_mut().queue);
+                let queue_size = queue.len();
+                if queue_size == 0 {
+                    break;
+                }
+
+                trace!("Starting NetExecutor loop with {queue_size} tasks");
+                for task in queue.drain(0..) {
+                    let task: Rc<NetTask> = Rc::new(task);
+                    let _ = unsafe {
+                        task.poll(
+                            &mut ContextBuilder::from_waker(Waker::noop())
+                                .local_waker(&task.clone().into())
+                                .build(),
+                        )
+                    };
+                }
+            }
+
+            trace!("Polling");
+            let events = {
+                let mut events = Events::new();
+                self.0
+                    .borrow()
+                    .poller
+                    .wait(&mut events, Some(Duration::new(100000, 0)))
+                    .unwrap();
+                events
+            };
+            let events_len = events.len();
+            trace!("Recieved {events_len} events from Poller");
+            for event in events.iter() {
+                let waker = {
+                    let mut inner = self.0.borrow_mut();
+                    inner.map.remove(&event.key)
+                };
+                if let Some(waker) = waker {
+                    waker.wake();
+                }
+            }
+
+            trace!("Reviewing timeouts");
+            let timeouts = self
+                .0
+                .borrow()
+                .timeouts
+                .iter()
+                .filter_map(|(k, (i, d))| match i.elapsed() > *d {
+                    true => Some(*k),
+                    false => None,
+                })
+                .collect::<Vec<usize>>();
+
+            let timeouts_len = timeouts.len();
+            trace!("Timing out {timeouts_len} fds");
+            let _ = timeouts
+                .iter()
+                .filter_map(|fd| self.0.borrow_mut().map.remove(fd))
+                .collect::<Vec<LocalWaker>>();
+        }
+    }
+
+    pub fn run_for(&self, duration: Duration) {
+        let start = Instant::now();
+        while start.elapsed() < duration {
+            loop {
+                let mut queue = std::mem::take(&mut self.0.borrow_mut().queue);
+                if queue.is_empty() {
+                    break;
+                }
+                for task in queue.drain(0..) {
+                    let task: Rc<NetTask> = Rc::new(task);
+                    let _ = unsafe {
+                        task.poll(
+                            &mut ContextBuilder::from_waker(Waker::noop())
+                                .local_waker(&task.clone().into())
+                                .build(),
+                        )
+                    };
+                }
+            }
+
+            let mut events = Events::new();
+            self.0
+                .borrow()
+                .poller
+                .wait(&mut events, Some(Duration::from_millis(10)))
+                .unwrap();
+
+            for event in events.iter() {
+                let waker = {
+                    let mut inner = self.0.borrow_mut();
+                    inner.map.remove(&event.key)
+                };
+                if let Some(waker) = waker {
+                    waker.wake();
+                }
+            }
+
+            let timeouts = self
+                .0
+                .borrow()
+                .timeouts
+                .iter()
+                .filter_map(|(k, (i, d))| if i.elapsed() > *d { Some(*k) } else { None })
+                .collect::<Vec<usize>>();
+
+            for fd in timeouts {
+                self.0.borrow_mut().map.remove(&fd);
+            }
+        }
+    }
 }

--- a/backend/src/futures/read_line.rs
+++ b/backend/src/futures/read_line.rs
@@ -1,45 +1,81 @@
-use std::task::Poll;
-use std::task::Context;
-use std::pin::Pin;
-use std::future::Future;
-use std::io::ErrorKind;
 use std::error::Error;
+use std::future::Future;
+use std::io::{BufRead, ErrorKind};
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
 use std::task::Poll::Ready;
-use std::io::BufRead;
 
 use crate::AsyncTcpStream;
 
 #[allow(unused_imports)]
-use log::{error, warn, info, debug, trace};
+use log::{debug, error, info, trace, warn};
 
 pub struct AsyncReadLineFuture<'a> {
-  stream: &'a mut AsyncTcpStream,
+    stream: &'a mut AsyncTcpStream,
+    buf: String,
 }
 impl<'a> AsyncReadLineFuture<'a> {
-  pub fn new(stream: &'a mut AsyncTcpStream) -> Self {
-    AsyncReadLineFuture { stream }
-  }
+    pub fn new(stream: &'a mut AsyncTcpStream) -> Self {
+        AsyncReadLineFuture {
+            stream,
+            buf: String::new(),
+        }
+    }
 }
 impl Future for AsyncReadLineFuture<'_> {
     type Output = Result<String, Box<dyn Error>>;
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
-      trace!("Poll called for AsyncReadLineFuture");
-      let reader = self.stream.reader();
-      let mut buffer = String::new();
+        trace!("Poll called for AsyncReadLineFuture");
 
-      // TODO this blocks :(
-      match reader.read_line(&mut buffer) {
-        Ok(_) => {
-          trace!("Poll read a line {buffer}");
-          Ready(Ok(buffer))
-        },
-        Err(e) if e.kind() == ErrorKind::WouldBlock => {
-          trace!("Poll returned WouldBlock");
-          self.stream.register(ctx.local_waker().clone());
-          Poll::Pending
-        },
-        Err(e) => Ready(Err(Box::new(e))),
-      }
+        loop {
+            let mut local = std::mem::take(&mut self.buf);
+            let mut consume = 0usize;
+            let mut complete = false;
+
+            {
+                let reader = self.stream.reader();
+                match reader.fill_buf() {
+                    Ok(buf) if buf.is_empty() => {
+                        complete = true;
+                    }
+                    Ok(buf) => {
+                        if let Some(pos) = buf.iter().position(|b| *b == b'\n') {
+                            let slice = &buf[..=pos];
+                            local.push_str(
+                                std::str::from_utf8(slice)
+                                    .map_err(|e| Box::new(e) as Box<dyn Error>)?,
+                            );
+                            consume = pos + 1;
+                            complete = true;
+                        } else {
+                            local.push_str(
+                                std::str::from_utf8(buf)
+                                    .map_err(|e| Box::new(e) as Box<dyn Error>)?,
+                            );
+                            consume = buf.len();
+                        }
+                    }
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                        self.buf = local;
+                        self.stream.register(ctx.local_waker().clone());
+                        return Poll::Pending;
+                    }
+                    Err(e) => return Ready(Err(Box::new(e))),
+                }
+            }
+
+            if consume > 0 {
+                self.stream.reader().consume(consume);
+            }
+
+            if complete {
+                trace!("Poll read a line {local}");
+                return Ready(Ok(local));
+            } else {
+                self.buf = local;
+            }
+        }
     }
 }

--- a/backend/tests/executor.rs
+++ b/backend/tests/executor.rs
@@ -1,0 +1,53 @@
+use backend::{AsyncTcpStream, NetExecutor};
+use std::io::Write;
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::channel;
+use std::time::Duration;
+
+#[test]
+fn executor_responsive_multiple_connections() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let executor = NetExecutor::new();
+
+    let mut c1 = TcpStream::connect(addr).unwrap();
+    let mut c2 = TcpStream::connect(addr).unwrap();
+
+    let (s1, _) = listener.accept().unwrap();
+    let (s2, _) = listener.accept().unwrap();
+
+    let mut a1 = AsyncTcpStream::new(s1, executor.clone()).unwrap();
+    let mut a2 = AsyncTcpStream::new(s2, executor.clone()).unwrap();
+
+    let (done_tx, done_rx) = channel();
+    let (l1_tx, l1_rx) = channel();
+    let (l2_tx, l2_rx) = channel();
+
+    executor.clone().spawn(async move {
+        let line = a1.read_line().await.unwrap();
+        l1_tx.send(line).unwrap();
+        std::future::pending::<()>().await;
+    });
+
+    executor.clone().spawn(async move {
+        let line = a2.read_line().await.unwrap();
+        l2_tx.send(line).unwrap();
+        std::future::pending::<()>().await;
+    });
+
+    executor.clone().spawn(async move {
+        done_tx.send(()).unwrap();
+    });
+
+    executor.run_for(Duration::from_millis(50));
+    assert!(done_rx.try_recv().is_ok());
+
+    c1.write_all(b"one\n").unwrap();
+    c2.write_all(b"two\n").unwrap();
+
+    executor.run_for(Duration::from_millis(50));
+
+    assert_eq!(l1_rx.try_recv().unwrap().trim(), "one");
+    assert_eq!(l2_rx.try_recv().unwrap().trim(), "two");
+}


### PR DESCRIPTION
## Summary
- implement manual non-blocking line reading
- wake wakers correctly in the executor
- add `run_for` helper for running the executor for a short time
- test multiple waiting connections

## Testing
- `cargo test -p backend -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_687ecdcd2aec832bbb897a6847704eb2