### PR TITLE
Add event registration flow

### DIFF
--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -1,5 +1,5 @@
-
 pub mod dashboard_route;
 //pub mod create_event_route;
 pub mod event_route;
 pub mod login;
+pub mod register_event_route;

--- a/backend/src/api/register_event_route.rs
+++ b/backend/src/api/register_event_route.rs
@@ -1,0 +1,32 @@
+use http::{Request, Response, StatusCode};
+use std::error::Error;
+
+use crate::{RegistrationCommand, RegistrationStore};
+use models::Registration;
+
+pub fn register_event_route(
+    _req: &Request<()>,
+    mut store: RegistrationStore,
+    event_id: String,
+    email: String,
+) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+    let registration = Registration {
+        id: format!("{}-{}", event_id, email),
+        event_id,
+        email,
+    };
+
+    store.command(&RegistrationCommand::CreateRegistration(
+        registration.clone(),
+    ))?;
+
+    let json = serde_json::to_vec(&registration)?;
+
+    Ok(Response::builder()
+        .status(StatusCode::CREATED)
+        .header("Content-Type", "application/json")
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "*")
+        .header("Access-Control-Allow-Headers", "*")
+        .body(json)?)
+}

--- a/backend/src/bin/backend.rs
+++ b/backend/src/bin/backend.rs
@@ -5,191 +5,206 @@ use std::path::Path;
 
 use backend::PlatformStore;
 use backend::{
-  NetExecutor,
-  AsyncTcpListener,
-  AsyncHttpRequest,
-  dashboard_store,
-  DashboardStore,
-  DashboardCommand,
-  PlatformCommand,
-  platform_store,
+    dashboard_store, platform_store, registration_store, AsyncHttpRequest, AsyncTcpListener,
+    DashboardCommand, DashboardStore, NetExecutor, PlatformCommand,
 };
 
-use models::{
-  Event,
-  Platform,
-  PlatformUser,
-  DashboardUser,
-};
+use models::{DashboardUser, Event, Platform, PlatformUser};
 
 use backend::{
-  not_found_route,
-  error_route,
-  dashboard_route,
-  event_details_route,
-  login_route,
+    dashboard_route, error_route, event_details_route, login_route, not_found_route,
+    register_event_route,
 };
 fn clear_directory(path: &str) -> io::Result<()> {
-  if Path::new(path).exists() {
-    for entry in fs::read_dir(path)? {
-      let entry = entry?;
-      let path = entry.path();
-      if path.is_file() {
-        fs::remove_file(path)?;
-      } else if path.is_dir() {
-        fs::remove_dir_all(path)?;
-      }
+    if Path::new(path).exists() {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file() {
+                fs::remove_file(path)?;
+            } else if path.is_dir() {
+                fs::remove_dir_all(path)?;
+            }
+        }
     }
-  }
-  Ok(())
+    Ok(())
 }
 
 pub fn seed_platform(platform_store: &mut PlatformStore) {
-  let platform = Platform {
-    tenant_id: "bucket-golf".into(),
-    community_name: "Bucket Golf Leagues".into(),
-    community_description: "Join the most exciting bucket golf leagues in the area!".into(),
-    platform_url: "https://bucketgolf.example.com".into(),
-  };
+    let platform = Platform {
+        tenant_id: "bucket-golf".into(),
+        community_name: "Bucket Golf Leagues".into(),
+        community_description: "Join the most exciting bucket golf leagues in the area!".into(),
+        platform_url: "https://bucketgolf.example.com".into(),
+    };
 
-  if let Err(e) = platform_store.command(&PlatformCommand::CreatePlatform(platform.clone())) {
-    eprintln!("Failed to insert platform: {:?}", e);
-  }
+    if let Err(e) = platform_store.command(&PlatformCommand::CreatePlatform(platform.clone())) {
+        eprintln!("Failed to insert platform: {:?}", e);
+    }
 
-  let user = PlatformUser::new(
-    "ryanbruno506@gmail.com".into(),
-    "hashed_password".into(),
-  );
-  if let Err(e) = platform_store.command(&PlatformCommand::CreateUser(user.clone())) {
-    eprintln!("Failed to insert user: {:?}", e);
-  }
+    let user = PlatformUser::new("ryanbruno506@gmail.com".into(), "hashed_password".into());
+    if let Err(e) = platform_store.command(&PlatformCommand::CreateUser(user.clone())) {
+        eprintln!("Failed to insert user: {:?}", e);
+    }
 
-  println!("✅ Platform seeded.");
+    println!("✅ Platform seeded.");
 }
 
 pub fn seed_example_events(dashboard_store: &mut DashboardStore) {
-  let examples = vec![
-    Event {
-      tenant_id: "bucket-golf".into(),
-      id: "1".into(),
-      name: "Arlington Bucket Golf League".into(),
-      location: "Quincy Park, VA".into(),
-      date: "Saturday, July 13 – 3:00 PM".into(),
-      image: "/static/bucket-golf.jpg".into(),
-      banner: Some("⚡ Almost Sold Out".into()),
-      upsell: Some("Only 3 slots left".into()),
-    },
-    Event {
-      tenant_id: "bucket-golf".into(),
-      id: "2".into(),
-      name: "Launch Meetup".into(),
-      location: "Liberty Park, DC".into(),
-      date: "Monday, July 15 – 5:00 PM".into(),
-      image: "/static/launch-meetup.jpg".into(),
-      banner: None,
-      upsell: None,
-    },
-    Event {
-      tenant_id: "bucket-golf".into(),
-      id: "3".into(),
-      name: "Weekly Planning Session".into(),
-      location: "National Mall, DC".into(),
-      date: "Wednesday, July 17 – 12:00 PM".into(),
-      image: "/static/planning.jpg".into(),
-      banner: Some("🆕 New".into()),
-      upsell: Some("Limited spots available".into()),
-    },
-  ];
+    let examples = vec![
+        Event {
+            tenant_id: "bucket-golf".into(),
+            id: "1".into(),
+            name: "Arlington Bucket Golf League".into(),
+            location: "Quincy Park, VA".into(),
+            date: "Saturday, July 13 – 3:00 PM".into(),
+            image: "/static/bucket-golf.jpg".into(),
+            banner: Some("⚡ Almost Sold Out".into()),
+            upsell: Some("Only 3 slots left".into()),
+        },
+        Event {
+            tenant_id: "bucket-golf".into(),
+            id: "2".into(),
+            name: "Launch Meetup".into(),
+            location: "Liberty Park, DC".into(),
+            date: "Monday, July 15 – 5:00 PM".into(),
+            image: "/static/launch-meetup.jpg".into(),
+            banner: None,
+            upsell: None,
+        },
+        Event {
+            tenant_id: "bucket-golf".into(),
+            id: "3".into(),
+            name: "Weekly Planning Session".into(),
+            location: "National Mall, DC".into(),
+            date: "Wednesday, July 17 – 12:00 PM".into(),
+            image: "/static/planning.jpg".into(),
+            banner: Some("🆕 New".into()),
+            upsell: Some("Limited spots available".into()),
+        },
+    ];
 
-  for event in examples {
-    if let Err(e) = dashboard_store.command(&DashboardCommand::CreateEvent(event.clone())) {
-      eprintln!("Failed to insert event {:?}: {:?}", event.name, e);
+    for event in examples {
+        if let Err(e) = dashboard_store.command(&DashboardCommand::CreateEvent(event.clone())) {
+            eprintln!("Failed to insert event {:?}: {:?}", event.name, e);
+        }
     }
-  }
 
-  let user = DashboardUser::new(
-    "ryanbruno506@gmail.com".into(),
-    "hashed_password".into(),
-  );
-  if let Err(e) = dashboard_store.command(&DashboardCommand::CreateUser(user.clone())) {
-    eprintln!("Failed to insert user: {:?}", e);
-  }
+    let user = DashboardUser::new("ryanbruno506@gmail.com".into(), "hashed_password".into());
+    if let Err(e) = dashboard_store.command(&DashboardCommand::CreateUser(user.clone())) {
+        eprintln!("Failed to insert user: {:?}", e);
+    }
 
-  dashboard_store.command(&DashboardCommand::SetName((
-    "bucket-golf".into(),
-    "Bucket Golf Leagues".into(),
-  ))).unwrap();
+    dashboard_store
+        .command(&DashboardCommand::SetName((
+            "bucket-golf".into(),
+            "Bucket Golf Leagues".into(),
+        )))
+        .unwrap();
 
-  dashboard_store.command(&DashboardCommand::SetAnnouncement((
+    dashboard_store.command(&DashboardCommand::SetAnnouncement((
     "bucket-golf".into(),
     "⛳️ New summer leagues of bucket golf just dropped. Rally your crew and start swinging!".into(),
   ))).unwrap();
 
-  println!("✅ Example events seeded.");
+    println!("✅ Example events seeded.");
 }
 
-
 #[allow(unused_imports)]
-use log::{error, warn, info, debug, trace};
+use log::{debug, error, info, trace, warn};
 
-pub fn main() -> Result<(), Box<dyn Error>>{
-  log4rs::init_file("log4rs.yml", Default::default()).unwrap();
+pub fn main() -> Result<(), Box<dyn Error>> {
+    log4rs::init_file("log4rs.yml", Default::default()).unwrap();
 
-  /* Clear and seed data for development */
-  clear_directory("data/")?;
-  let mut dashboard_store = dashboard_store()?;
-  let mut platform_store = platform_store()?;
-  seed_example_events(&mut dashboard_store);
-  seed_platform(&mut platform_store);
-  dashboard_store.fold()?;
-  platform_store.fold()?;
+    /* Clear and seed data for development */
+    clear_directory("data/")?;
+    let mut dashboard_store = dashboard_store()?;
+    let mut platform_store = platform_store()?;
+    let mut registration_store = registration_store()?;
+    seed_example_events(&mut dashboard_store);
+    seed_platform(&mut platform_store);
+    dashboard_store.fold()?;
+    platform_store.fold()?;
+    registration_store.fold()?;
 
-  /* Start the server */
-  let executor = NetExecutor::new();
-  let listener = AsyncTcpListener::new(8000, executor.clone()).unwrap();
-  let server = AsyncHttpRequest::new(listener, executor.clone());
+    /* Start the server */
+    let executor = NetExecutor::new();
+    let listener = AsyncTcpListener::new(8000, executor.clone()).unwrap();
+    let server = AsyncHttpRequest::new(listener, executor.clone());
 
-  executor.clone().spawn(async move {
-    loop {
-      /* Wait for a new request */
-      let (request, mut stream) = server.next_request().await.unwrap();
+    executor.clone().spawn(async move {
+        loop {
+            /* Wait for a new request */
+            let (request, mut stream) = server.next_request().await.unwrap();
 
-      /* Process the request */
-      let response = match request.uri().path() {
-        "/dashboard" => dashboard_route(
-          &request, dashboard_store.clone(),
-          request.headers().get("x-tenant_id")
-            .and_then(|v| v.to_str().ok()).unwrap_or_default()
-            .to_string(),
-        ),
-        "/dashboard/event" => event_details_route(
-          &request, dashboard_store.clone(),
-          request.headers().get("x-id")
-            .and_then(|v| v.to_str().ok()).unwrap_or_default()
-            .to_string()
-        ),
-        "/dashboard/login" => panic!(),
-        "/platform/login" => login_route(
-          &request, platform_store.clone(),
-          request.headers().get("x-email")
-            .and_then(|v| v.to_str().ok()).unwrap_or_default()
-            .to_string(),
-          request.headers().get("x-password")
-            .and_then(|v| v.to_str().ok()).unwrap_or_default()
-            .to_string(),
-        ),
+            /* Process the request */
+            let response = match request.uri().path() {
+                "/dashboard" => dashboard_route(
+                    &request,
+                    dashboard_store.clone(),
+                    request
+                        .headers()
+                        .get("x-tenant_id")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                ),
+                "/dashboard/event" => event_details_route(
+                    &request,
+                    dashboard_store.clone(),
+                    request
+                        .headers()
+                        .get("x-id")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                ),
+                "/dashboard/register_event" => register_event_route(
+                    &request,
+                    registration_store.clone(),
+                    request
+                        .headers()
+                        .get("x-id")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                    request
+                        .headers()
+                        .get("x-email")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("guest@example.com")
+                        .to_string(),
+                ),
+                "/dashboard/login" => panic!(),
+                "/platform/login" => login_route(
+                    &request,
+                    platform_store.clone(),
+                    request
+                        .headers()
+                        .get("x-email")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                    request
+                        .headers()
+                        .get("x-password")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                ),
 
-        _ => not_found_route(),
-      }.unwrap_or_else(|e| {
-        error!("Error processing request: {e}");
-        error_route()
-      });
+                _ => not_found_route(),
+            }
+            .unwrap_or_else(|e| {
+                error!("Error processing request: {e}");
+                error_route()
+            });
 
-      /* Write the response back to the client */
-      AsyncHttpRequest::write_response(&mut stream, response).await;
-    }
-  });
+            /* Write the response back to the client */
+            AsyncHttpRequest::write_response(&mut stream, response).await;
+        }
+    });
 
-  executor.run();
-  Ok(())
+    executor.run();
+    Ok(())
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,37 +1,39 @@
 #![feature(local_waker)]
 
 mod executor;
+pub use crate::executor::BoxFuture;
 pub use crate::executor::NetExecutor;
 pub use crate::executor::NetTask;
-pub use crate::executor::BoxFuture;
 mod r#async;
+pub use crate::r#async::AsyncHttpRequest;
 pub use crate::r#async::AsyncTcpListener;
 pub use crate::r#async::AsyncTcpStream;
-pub use crate::r#async::AsyncHttpRequest;
 mod futures;
-pub use crate::futures::AsyncTcpStreamFuture;
 pub use crate::futures::AsyncReadLineFuture;
+pub use crate::futures::AsyncTcpStreamFuture;
 pub use crate::futures::AsyncWriteAllFuture;
 
 mod utils;
-pub use crate::utils::channel::{Receiver, Sender, channel};
+pub use crate::utils::channel::{channel, Receiver, Sender};
 pub use crate::utils::error::GenericError;
-pub use crate::utils::responses::{
-    serve_route,
-    not_found_route,
-    error_route,
-};
+pub use crate::utils::responses::{error_route, not_found_route, serve_route};
 
 pub mod api;
 pub use crate::api::dashboard_route::dashboard_route;
 //pub use crate::api::create_event_route::create_event_route;
 pub use crate::api::event_route::event_details_route;
 pub use crate::api::login::login_route;
+pub use crate::api::register_event_route::register_event_route;
 
 pub mod database;
-pub use crate::database::kv_store::KVStore;
 pub use crate::database::cqrs_store::{CQRSStore, Command};
+pub use crate::database::kv_store::KVStore;
 
 pub mod store;
-pub use crate::store::dashboard::{DashboardCommand, DashboardModel, DashboardStore, dashboard_store};
-pub use crate::store::platform::{PlatformCommand, PlatformModel, PlatformStore, platform_store};
+pub use crate::store::dashboard::{
+    dashboard_store, DashboardCommand, DashboardModel, DashboardStore,
+};
+pub use crate::store::dashboard::{
+    registration_store, RegistrationCommand, RegistrationModel, RegistrationStore,
+};
+pub use crate::store::platform::{platform_store, PlatformCommand, PlatformModel, PlatformStore};

--- a/backend/src/store/dashboard.rs
+++ b/backend/src/store/dashboard.rs
@@ -1,152 +1,252 @@
-use std::error::Error;
-use crate::{
-  CQRSStore, Command, KVStore
-};
+use crate::{CQRSStore, Command, KVStore};
 use models::{
-  Event,
-  EventPatch,
-  Patch,
-  EntityId,
-  DashboardData,
-  DashboardUser, DashboardUserPatch
+    DashboardData, DashboardUser, DashboardUserPatch, EntityId, Event, EventPatch, Patch,
+    Registration, RegistrationPatch,
 };
-use rkyv::{
-    Archive, Deserialize, Serialize,
-};
+use rkyv::{Archive, Deserialize, Serialize};
+use std::error::Error;
 
-use std::rc::Rc;
-use std::cell::RefCell;
 use std::cell::Ref;
+use std::cell::RefCell;
+use std::rc::Rc;
 
 #[derive(Default, Clone, Archive, Serialize, Deserialize)]
 pub enum DashboardCommand {
-  #[default]
-  Noop,
-  /* Events */
-  CreateEvent(Event),
-  UpdateEvent((String, EntityId, EventPatch)),
+    #[default]
+    Noop,
+    /* Events */
+    CreateEvent(Event),
+    UpdateEvent((String, EntityId, EventPatch)),
 
-  /* User */
-  CreateUser(DashboardUser),
-  UpdateUser((String, DashboardUserPatch)),
-  /* Dashboard Info */
-  SetAnnouncement((EntityId, String)),
-  SetName((EntityId, String)),
+    /* User */
+    CreateUser(DashboardUser),
+    UpdateUser((String, DashboardUserPatch)),
+    /* Dashboard Info */
+    SetAnnouncement((EntityId, String)),
+    SetName((EntityId, String)),
 }
 
 #[derive(Default, Clone, Archive, Serialize, Deserialize)]
 pub enum DashboardModel {
-  #[default]
-  Noop,
-  DashboardData(DashboardData),
-  Event(Event),
-  User(DashboardUser),
+    #[default]
+    Noop,
+    DashboardData(DashboardData),
+    Event(Event),
+    User(DashboardUser),
+}
+
+#[derive(Default, Clone, Archive, Serialize, Deserialize)]
+pub enum RegistrationCommand {
+    #[default]
+    Noop,
+    CreateRegistration(Registration),
+    UpdateRegistration((EntityId, RegistrationPatch)),
+}
+
+#[derive(Default, Clone, Archive, Serialize, Deserialize)]
+pub enum RegistrationModel {
+    #[default]
+    Noop,
+    Registration(Registration),
 }
 
 impl Patch<DashboardModel> for DashboardCommand {
-  fn apply_to(self, target: &mut DashboardModel) -> () {
-    match (self, target) {
-      (DashboardCommand::CreateEvent(event), DashboardModel::DashboardData(view)) => {
-        // Add Event to dashboard view
-        view.events.retain(|e| e.id != event.id);
-        view.events.push(event.clone());
-      },
-      (DashboardCommand::CreateEvent(event), target) => {
-        // Create a new dashboard view with the event
-        *target = DashboardModel::DashboardData(DashboardData {
-          announcement: String::new(),
-          name: String::new(),
-          events: vec![event.clone()],
-        });
-      },
-      (DashboardCommand::UpdateEvent((_tenant_id, _id, patch)), DashboardModel::Event(event)) => {
-        // Apply patch to event
-        patch.apply_to(event);
-      },
-      (DashboardCommand::UpdateEvent((_tenant_id, id, patch)), DashboardModel::DashboardData(view)) => {
-        // Apply patch to event
-        patch.apply_to(view.events.iter_mut().find(|e| e.id == id).unwrap());
-      },
-      (DashboardCommand::SetAnnouncement((_tenant_id, announcement)), DashboardModel::DashboardData(view)) => {
-        // Set announcement in dashboard view
-        view.announcement = announcement;
-      },
-      (DashboardCommand::SetName((_tenant_id, name)), DashboardModel::DashboardData(view)) => {
-        // Set name in dashboard view
-        view.name = name;
-      },
-      _ => {},
+    fn apply_to(self, target: &mut DashboardModel) -> () {
+        match (self, target) {
+            (DashboardCommand::CreateEvent(event), DashboardModel::DashboardData(view)) => {
+                // Add Event to dashboard view
+                view.events.retain(|e| e.id != event.id);
+                view.events.push(event.clone());
+            }
+            (DashboardCommand::CreateEvent(event), target) => {
+                // Create a new dashboard view with the event
+                *target = DashboardModel::DashboardData(DashboardData {
+                    announcement: String::new(),
+                    name: String::new(),
+                    events: vec![event.clone()],
+                });
+            }
+            (
+                DashboardCommand::UpdateEvent((_tenant_id, _id, patch)),
+                DashboardModel::Event(event),
+            ) => {
+                // Apply patch to event
+                patch.apply_to(event);
+            }
+            (
+                DashboardCommand::UpdateEvent((_tenant_id, id, patch)),
+                DashboardModel::DashboardData(view),
+            ) => {
+                // Apply patch to event
+                patch.apply_to(view.events.iter_mut().find(|e| e.id == id).unwrap());
+            }
+            (
+                DashboardCommand::SetAnnouncement((_tenant_id, announcement)),
+                DashboardModel::DashboardData(view),
+            ) => {
+                // Set announcement in dashboard view
+                view.announcement = announcement;
+            }
+            (
+                DashboardCommand::SetName((_tenant_id, name)),
+                DashboardModel::DashboardData(view),
+            ) => {
+                // Set name in dashboard view
+                view.name = name;
+            }
+            _ => {}
+        }
     }
-  }
 }
 
 impl Command<DashboardModel, DashboardCommand> for DashboardCommand {
-  fn fold(&self, kv_store: &mut KVStore<DashboardModel, DashboardCommand>) -> Result<(), Box<dyn Error>> {
-    match self {
-      DashboardCommand::CreateEvent(event) => {
-        /* Create Event */
-        kv_store.create(event.id.clone(), DashboardModel::Event(event.clone()))?;
-        /* Update Tenant's Dashboard */
-        kv_store.update(event.tenant_id.clone(), self.clone())?;
-      },
-      DashboardCommand::UpdateEvent((tenant_id, id, _patch)) => {
-        /* Update Event */
-        kv_store.update(id.clone(), self.clone())?;
-        /* Update Tenant's Dashboard */
-        kv_store.update(tenant_id.clone(), self.clone())?;
-      },
-      DashboardCommand::SetAnnouncement((tenant_id, _announcement)) => {
-        kv_store.update(tenant_id.clone(), self.clone())?;
-      },
-      DashboardCommand::SetName((tenant_id, _name)) => {
-        kv_store.update(tenant_id.clone(), self.clone())?;
-      },
-      DashboardCommand::CreateUser(user) => {
-        /* Create User */
-        kv_store.create(format!("user-{}", user.email),DashboardModel::User(user.clone()))?;
-      },
-      DashboardCommand::UpdateUser((email, _user)) => {
-        /* Update User */
-        kv_store.update(format!("user-{}", email), self.clone())?;
-      },
-      DashboardCommand::Noop => {},
+    fn fold(
+        &self,
+        kv_store: &mut KVStore<DashboardModel, DashboardCommand>,
+    ) -> Result<(), Box<dyn Error>> {
+        match self {
+            DashboardCommand::CreateEvent(event) => {
+                /* Create Event */
+                kv_store.create(event.id.clone(), DashboardModel::Event(event.clone()))?;
+                /* Update Tenant's Dashboard */
+                kv_store.update(event.tenant_id.clone(), self.clone())?;
+            }
+            DashboardCommand::UpdateEvent((tenant_id, id, _patch)) => {
+                /* Update Event */
+                kv_store.update(id.clone(), self.clone())?;
+                /* Update Tenant's Dashboard */
+                kv_store.update(tenant_id.clone(), self.clone())?;
+            }
+            DashboardCommand::SetAnnouncement((tenant_id, _announcement)) => {
+                kv_store.update(tenant_id.clone(), self.clone())?;
+            }
+            DashboardCommand::SetName((tenant_id, _name)) => {
+                kv_store.update(tenant_id.clone(), self.clone())?;
+            }
+            DashboardCommand::CreateUser(user) => {
+                /* Create User */
+                kv_store.create(
+                    format!("user-{}", user.email),
+                    DashboardModel::User(user.clone()),
+                )?;
+            }
+            DashboardCommand::UpdateUser((email, _user)) => {
+                /* Update User */
+                kv_store.update(format!("user-{}", email), self.clone())?;
+            }
+            DashboardCommand::Noop => {}
+        }
+        Ok(())
     }
-    Ok(())
-  }
+}
+
+impl Patch<RegistrationModel> for RegistrationCommand {
+    fn apply_to(self, target: &mut RegistrationModel) {
+        match (self, target) {
+            (RegistrationCommand::CreateRegistration(r), RegistrationModel::Registration(t)) => {
+                *t = r;
+            }
+            (
+                RegistrationCommand::UpdateRegistration((_id, patch)),
+                RegistrationModel::Registration(t),
+            ) => {
+                patch.apply_to(t);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Command<RegistrationModel, RegistrationCommand> for RegistrationCommand {
+    fn fold(
+        &self,
+        kv_store: &mut KVStore<RegistrationModel, RegistrationCommand>,
+    ) -> Result<(), Box<dyn Error>> {
+        match self {
+            RegistrationCommand::CreateRegistration(reg) => {
+                kv_store.create(reg.id.clone(), RegistrationModel::Registration(reg.clone()))?;
+            }
+            RegistrationCommand::UpdateRegistration((id, _patch)) => {
+                kv_store.update(id.clone(), self.clone())?;
+            }
+            RegistrationCommand::Noop => {}
+        }
+        Ok(())
+    }
 }
 
 pub type DashboardStoreInner = CQRSStore<DashboardCommand, DashboardModel, DashboardCommand>;
 #[derive(Clone)]
 pub struct DashboardStore {
-  inner: Rc<RefCell<DashboardStoreInner>>,
+    inner: Rc<RefCell<DashboardStoreInner>>,
 }
 
 impl DashboardStore {
-  pub fn new(store: DashboardStoreInner) -> Self {
-    Self { inner: Rc::new(RefCell::new(store)) }
-  }
+    pub fn new(store: DashboardStoreInner) -> Self {
+        Self {
+            inner: Rc::new(RefCell::new(store)),
+        }
+    }
 
-  pub fn command(&mut self, command: &DashboardCommand) -> Result<(), Box<dyn Error>> {
-    self.inner.borrow_mut().command(command)
-  }
+    pub fn command(&mut self, command: &DashboardCommand) -> Result<(), Box<dyn Error>> {
+        self.inner.borrow_mut().command(command)
+    }
 
-  pub fn borrow_inner(&self) -> Ref<DashboardStoreInner> {
-    self.inner.borrow()
-  }
+    pub fn borrow_inner(&self) -> Ref<DashboardStoreInner> {
+        self.inner.borrow()
+    }
 
-  pub fn fold(&mut self) -> Result<(), Box<dyn Error>> {
-    self.inner.borrow_mut().fold()
-  }
+    pub fn fold(&mut self) -> Result<(), Box<dyn Error>> {
+        self.inner.borrow_mut().fold()
+    }
 }
 
 pub fn dashboard_store() -> Result<DashboardStore, Box<dyn Error>> {
-  Ok(DashboardStore::new(
-  DashboardStoreInner::new(
-    "data/dashboard/transactions/".into(),
-    KVStore::new(
-      "data/dashboard/snapshots/".into(),
-      "data/dashboard/events/".into(),
-      10,
-    )?
-  )))
+    Ok(DashboardStore::new(DashboardStoreInner::new(
+        "data/dashboard/transactions/".into(),
+        KVStore::new(
+            "data/dashboard/snapshots/".into(),
+            "data/dashboard/events/".into(),
+            10,
+        )?,
+    )))
+}
+
+pub type RegistrationStoreInner =
+    CQRSStore<RegistrationCommand, RegistrationModel, RegistrationCommand>;
+
+#[derive(Clone)]
+pub struct RegistrationStore {
+    inner: Rc<RefCell<RegistrationStoreInner>>,
+}
+
+impl RegistrationStore {
+    pub fn new(store: RegistrationStoreInner) -> Self {
+        Self {
+            inner: Rc::new(RefCell::new(store)),
+        }
+    }
+
+    pub fn command(&mut self, command: &RegistrationCommand) -> Result<(), Box<dyn Error>> {
+        self.inner.borrow_mut().command(command)
+    }
+
+    pub fn borrow_inner(&self) -> Ref<RegistrationStoreInner> {
+        self.inner.borrow()
+    }
+
+    pub fn fold(&mut self) -> Result<(), Box<dyn Error>> {
+        self.inner.borrow_mut().fold()
+    }
+}
+
+pub fn registration_store() -> Result<RegistrationStore, Box<dyn Error>> {
+    Ok(RegistrationStore::new(RegistrationStoreInner::new(
+        "data/registration/transactions/".into(),
+        KVStore::new(
+            "data/registration/snapshots/".into(),
+            "data/registration/events/".into(),
+            10,
+        )?,
+    )))
 }

--- a/frontend/src/hooks/mod.rs
+++ b/frontend/src/hooks/mod.rs
@@ -1,5 +1,5 @@
-
 pub mod use_dashboard_api;
+pub mod use_dashboard_login;
 pub mod use_event;
 pub mod use_platform_login;
-pub mod use_dashboard_login;
+pub mod use_register_event;

--- a/frontend/src/hooks/use_register_event.rs
+++ b/frontend/src/hooks/use_register_event.rs
@@ -1,0 +1,36 @@
+use crate::{ClientContext, ToastContext, ToastKind, ToastMessage};
+use dioxus::prelude::*;
+use models::Registration;
+
+pub fn use_register_event(
+    trigger: Signal<Option<(String, String)>>,
+    mut toast: Signal<ToastContext>,
+    client: Signal<ClientContext>,
+) -> Resource<Option<Registration>> {
+    use_resource(move || async move {
+        let Some((event_id, email)) = &*trigger.read() else {
+            return None;
+        };
+        let result = client()
+            .client
+            .post("http://localhost:8000/dashboard/register_event")
+            .header("x-id", event_id.clone())
+            .header("x-email", email.clone())
+            .send()
+            .await;
+        let parsed = match result {
+            Ok(resp) => resp.json::<Registration>().await,
+            Err(e) => Err(e),
+        };
+        match parsed {
+            Ok(reg) => Some(reg),
+            Err(_) => {
+                toast.write().toast = Some(ToastMessage {
+                    message: "Failed to register".to_string(),
+                    kind: ToastKind::Error,
+                });
+                None
+            }
+        }
+    })
+}

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -4,31 +4,31 @@ pub mod hooks;
 pub use hooks::use_dashboard_api::use_dashboard_api;
 pub use hooks::use_event::use_event;
 pub use hooks::use_platform_login::use_platform_login;
+pub use hooks::use_register_event::use_register_event;
 
 pub mod components;
-pub use components::toast::Toast;
 pub use components::notifications::NotificationsDropdown;
-
+pub use components::toast::Toast;
 
 pub mod context;
+pub use context::brand::BrandContext;
+pub use context::client::ClientContext;
+pub use context::toast::Toast as ToastMessage;
 pub use context::toast::ToastContext;
 pub use context::toast::ToastKind;
-pub use context::toast::Toast as ToastMessage;
-pub use context::client::ClientContext;
-pub use context::brand::BrandContext;
 
 pub mod pages;
-pub use pages::homepage::Homepage;
-pub use pages::login::Login;
-pub use pages::signup::Signup;
-pub use pages::get_started::GetStarted;
-pub use pages::get_started::ConfigurePlatform;
-pub use pages::not_found::PageNotFound;
-pub use pages::dashboard::Dashboard;
 pub use pages::create_event::CreateEvent;
+pub use pages::dashboard::Dashboard;
 pub use pages::event_details::EventDetails;
 pub use pages::event_register::RegisterEvent;
+pub use pages::get_started::ConfigurePlatform;
+pub use pages::get_started::GetStarted;
+pub use pages::homepage::Homepage;
+pub use pages::login::Login;
+pub use pages::not_found::PageNotFound;
 pub use pages::profile::ProfilePage;
+pub use pages::signup::Signup;
 
 #[derive(Routable, Clone, PartialEq)]
 pub enum Route {

--- a/frontend/src/pages/event_register.rs
+++ b/frontend/src/pages/event_register.rs
@@ -1,23 +1,24 @@
+use crate::{use_event, use_register_event, ClientContext, ToastContext};
 use dioxus::prelude::*;
-use crate::{use_event, ToastContext, ClientContext};
 const BUCKET_GOLF_SVG: Asset = asset!("/assets/bucket-golf.png");
 
 #[component]
 pub fn RegisterEvent(id: String) -> Element {
-    let data = use_event(id,
-      use_context::<Signal<ToastContext>>(),
-      use_context::<Signal<ClientContext>>(),
+    let data = use_event(
+        id,
+        use_context::<Signal<ToastContext>>(),
+        use_context::<Signal<ClientContext>>(),
     );
 
     match data.read_unchecked().as_ref() {
         Some(Some(event)) => rsx!(RegisterEventInner {
-          id: event.id.clone(),
-          name: event.name.clone(),
-          location: event.location.clone(),
-          date: event.date.clone(),
-          image: event.image.clone(),
-          banner: event.banner.clone(),
-          upsell: event.upsell.clone()
+            id: event.id.clone(),
+            name: event.name.clone(),
+            location: event.location.clone(),
+            date: event.date.clone(),
+            image: event.image.clone(),
+            banner: event.banner.clone(),
+            upsell: event.upsell.clone()
         }),
         _ => rsx!(),
     }
@@ -25,17 +26,25 @@ pub fn RegisterEvent(id: String) -> Element {
 
 #[component]
 pub fn RegisterEventInner(
-  id: String,
-  name: String,
-  location: String,
-  date: String,
-  image: String,
-  banner: Option<String>,
-  upsell: Option<String>,
+    id: String,
+    name: String,
+    location: String,
+    date: String,
+    image: String,
+    banner: Option<String>,
+    upsell: Option<String>,
 ) -> Element {
-  rsx!(
-    div {
-      style: "
+    let mut email = use_signal(|| String::new());
+    let mut trigger = use_signal(|| None);
+    let _reg = use_register_event(
+        trigger,
+        use_context::<Signal<ToastContext>>(),
+        use_context::<Signal<ClientContext>>(),
+    );
+
+    rsx!(
+      div {
+        style: "
         min-height: 100vh;
         background-color: #f9fafb;
         font-family: sans-serif;
@@ -43,8 +52,8 @@ pub fn RegisterEventInner(
         display: flex;
         justify-content: center;
       ",
-      div {
-        style: "
+        div {
+          style: "
           max-width: 48rem;
           width: 100%;
           background: white;
@@ -53,94 +62,98 @@ pub fn RegisterEventInner(
           box-shadow: 0 4px 12px rgba(0,0,0,0.05);
         ",
 
-        // Banner
-        if let Some(b) = banner.clone() {
-          div {
-            style: "background-color: #fde68a; color: #78350f; font-weight: bold; text-align: center; padding: 0.5rem; margin-bottom: 1rem;",
-            "{b}"
+          // Banner
+          if let Some(b) = banner.clone() {
+            div {
+              style: "background-color: #fde68a; color: #78350f; font-weight: bold; text-align: center; padding: 0.5rem; margin-bottom: 1rem;",
+              "{b}"
+            }
           }
-        }
 
-        // Event header
-        h1 {
-          style: "font-size: 2rem; font-weight: bold; color: #111827; margin-bottom: 0.5rem;",
-          "Register for {name}"
-        }
+          // Event header
+          h1 {
+            style: "font-size: 2rem; font-weight: bold; color: #111827; margin-bottom: 0.5rem;",
+            "Register for {name}"
+          }
 
-        p {
-          style: "color: #6b7280; margin-bottom: 1.5rem;",
-          "{date} · {location}"
-        }
-
-        img {
-          src: BUCKET_GOLF_SVG,
-          alt: "Event image",
-          style: "width: 100%; max-height: 200px; object-fit: cover; border-radius: 0.5rem; margin-bottom: 2rem;"
-        }
-
-        if let Some(u) = upsell.clone() {
           p {
-            style: "color: #dc2626; font-weight: 500; font-size: 0.95rem; margin-bottom: 1.5rem;",
-            "{u}"
-          }
-        }
-
-        // Pricing breakdown
-        div {
-          style: "margin-bottom: 2rem;",
-          h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Order Summary" }
-          ul {
-            style: "font-size: 0.95rem; color: #374151; margin-bottom: 1rem;",
-            li { "🏷️ Registration Fee: $20.00" }
-            li { "⚙️ Service Fee: $2.00" }
-            li { "📊 Taxes: $1.80" }
-            li { "💖 Optional Donation: $0.00" }
-          }
-          p { style: "font-weight: bold; font-size: 1.125rem; margin-top: 1rem;", "Total: $23.80" }
-        }
-
-        // Auth options
-        div {
-          style: "margin-bottom: 2rem;",
-          h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Your Account" }
-
-          input {
-            r#type: "email",
-            placeholder: "Email address",
-            style: base_input()
+            style: "color: #6b7280; margin-bottom: 1.5rem;",
+            "{date} · {location}"
           }
 
-          input {
-            r#type: "password",
-            placeholder: "Create a password or enter existing",
-            style: base_input()
+          img {
+            src: BUCKET_GOLF_SVG,
+            alt: "Event image",
+            style: "width: 100%; max-height: 200px; object-fit: cover; border-radius: 0.5rem; margin-bottom: 2rem;"
           }
 
-          a {
-            href: "#",
-            style: "font-size: 0.875rem; color: #4f46e5; text-decoration: underline;",
-            "Already have an account? Log in"
+          if let Some(u) = upsell.clone() {
+            p {
+              style: "color: #dc2626; font-weight: 500; font-size: 0.95rem; margin-bottom: 1.5rem;",
+              "{u}"
+            }
           }
-        }
 
-        // Billing address
-        div {
-          style: "margin-bottom: 2rem;",
-          h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Billing Address" }
-
-          input { placeholder: "Full Name", style: base_input() }
-          input { placeholder: "Street Address", style: base_input() }
-          input { placeholder: "City", style: base_input() }
-          input { placeholder: "State", style: base_input() }
-          input { placeholder: "Zip Code", style: base_input() }
-        }
-
-        // Payment section placeholder
-        div {
-          style: "margin-bottom: 2rem;",
-          h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Payment" }
+          // Pricing breakdown
           div {
-            style: "
+            style: "margin-bottom: 2rem;",
+            h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Order Summary" }
+            ul {
+              style: "font-size: 0.95rem; color: #374151; margin-bottom: 1rem;",
+              li { "🏷️ Registration Fee: $20.00" }
+              li { "⚙️ Service Fee: $2.00" }
+              li { "📊 Taxes: $1.80" }
+              li { "💖 Optional Donation: $0.00" }
+            }
+            p { style: "font-weight: bold; font-size: 1.125rem; margin-top: 1rem;", "Total: $23.80" }
+          }
+
+          // Auth options
+          div {
+            style: "margin-bottom: 2rem;",
+            h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Your Account" }
+
+            input {
+              r#type: "email",
+              placeholder: "Email address",
+              oninput: move |e| {
+                email.set(e.value());
+              },
+              value: email,
+              style: base_input()
+            }
+
+            input {
+              r#type: "password",
+              placeholder: "Create a password or enter existing",
+              style: base_input()
+            }
+
+            a {
+              href: "#",
+              style: "font-size: 0.875rem; color: #4f46e5; text-decoration: underline;",
+              "Already have an account? Log in"
+            }
+          }
+
+          // Billing address
+          div {
+            style: "margin-bottom: 2rem;",
+            h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Billing Address" }
+
+            input { placeholder: "Full Name", style: base_input() }
+            input { placeholder: "Street Address", style: base_input() }
+            input { placeholder: "City", style: base_input() }
+            input { placeholder: "State", style: base_input() }
+            input { placeholder: "Zip Code", style: base_input() }
+          }
+
+          // Payment section placeholder
+          div {
+            style: "margin-bottom: 2rem;",
+            h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Payment" }
+            div {
+              style: "
               padding: 1.5rem;
               border: 2px dashed #d1d5db;
               border-radius: 0.5rem;
@@ -148,12 +161,12 @@ pub fn RegisterEventInner(
               color: #9ca3af;
               font-size: 0.95rem;
             ",
-            "💳 Payment integration coming soon..."
+              "💳 Payment integration coming soon..."
+            }
           }
-        }
 
-        button {
-          style: "
+          button {
+            style: "
             width: 100%;
             background-color: #4f46e5;
             color: white;
@@ -164,15 +177,18 @@ pub fn RegisterEventInner(
             border-radius: 0.5rem;
             cursor: pointer;
           ",
-          "Complete Registration"
+            onclick: move |_| {
+              trigger.set(Some((id.clone(), email())));
+            },
+            "Complete Registration"
+          }
         }
       }
-    }
-  )
+    )
 }
 
 fn base_input() -> &'static str {
-  "
+    "
     width: 100%;
     padding: 0.75rem;
     margin-bottom: 0.75rem;

--- a/models/src/dashboard/mod.rs
+++ b/models/src/dashboard/mod.rs
@@ -1,4 +1,4 @@
-
 pub mod event;
+pub mod registration;
 pub mod store;
 pub mod user;

--- a/models/src/dashboard/registration.rs
+++ b/models/src/dashboard/registration.rs
@@ -1,0 +1,44 @@
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+use serde::{Deserialize as SarDeserialize, Serialize as SarSerialize};
+
+use crate::Patch;
+
+#[derive(
+    Archive,
+    RkyvDeserialize,
+    RkyvSerialize,
+    SarSerialize,
+    SarDeserialize,
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+)]
+pub struct Registration {
+    pub id: String,
+    pub event_id: String,
+    pub email: String,
+}
+
+#[derive(
+    Archive,
+    RkyvDeserialize,
+    RkyvSerialize,
+    SarSerialize,
+    SarDeserialize,
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+)]
+pub struct RegistrationPatch {
+    pub email: Option<String>,
+}
+
+impl Patch<Registration> for RegistrationPatch {
+    fn apply_to(self, target: &mut Registration) {
+        if let Some(email) = self.email {
+            target.email = email;
+        }
+    }
+}

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -1,14 +1,14 @@
-
 mod platform;
-pub use platform::user::{PlatformUser, PlatformUserPatch, LoginAttempt};
 pub use platform::platform::{Platform, PlatformPatch};
+pub use platform::user::{LoginAttempt, PlatformUser, PlatformUserPatch};
 
 mod dashboard;
+pub use dashboard::event::{ArchivedEvent, Event, EventPatch};
+pub use dashboard::registration::{Registration, RegistrationPatch};
 pub use dashboard::store::{DashboardData, DashboardView};
-pub use dashboard::event::{Event, EventPatch, ArchivedEvent};
 pub use dashboard::user::{DashboardUser, DashboardUserPatch};
 
 mod utils;
-pub use utils::{EntityId, Patch};
 #[cfg(not(target_arch = "wasm32"))]
 pub use utils::{hash_password, verify_password};
+pub use utils::{EntityId, Patch};


### PR DESCRIPTION
## Summary
- add `Registration` models
- support `RegistrationCommand` in dashboard store
- expose new `register_event_route` API endpoint
- wire up frontend hook and page to call registration route

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687ecdae81f4832bac1fee0d908eed25