### PR TITLE
Add dashboard login route

### DIFF
--- a/backend/src/api/dashboard_login.rs
+++ b/backend/src/api/dashboard_login.rs
@@ -1,0 +1,36 @@
+use http::Request;
+use http::Response;
+use http::StatusCode;
+use std::error::Error;
+
+use crate::not_found_route;
+use crate::{DashboardModel, DashboardStore};
+use models::LoginAttempt;
+
+pub fn dashboard_login_route(
+    _req: &Request<()>,
+    dashboard_store: DashboardStore,
+    email: String,
+    password: String,
+) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+    let user = dashboard_store
+        .borrow_inner()
+        .query_owned(format!("user-{}", email.clone()))?;
+
+    let login_attempt = LoginAttempt { email, password };
+
+    match user {
+        Some(DashboardModel::User(user)) if user == login_attempt => {
+            let json = serde_json::to_vec(&user)?;
+
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
+                .body(json)?)
+        }
+        _ => not_found_route(),
+    }
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -1,5 +1,6 @@
 
 pub mod dashboard_route;
+pub mod dashboard_login;
 //pub mod create_event_route;
 pub mod event_route;
 pub mod login;

--- a/backend/src/bin/backend.rs
+++ b/backend/src/bin/backend.rs
@@ -27,6 +27,7 @@ use backend::{
   error_route,
   dashboard_route,
   event_details_route,
+  dashboard_login_route,
   login_route,
 };
 fn clear_directory(path: &str) -> io::Result<()> {
@@ -168,7 +169,15 @@ pub fn main() -> Result<(), Box<dyn Error>>{
             .and_then(|v| v.to_str().ok()).unwrap_or_default()
             .to_string()
         ),
-        "/dashboard/login" => panic!(),
+        "/dashboard/login" => dashboard_login_route(
+          &request, dashboard_store.clone(),
+          request.headers().get("x-email")
+            .and_then(|v| v.to_str().ok()).unwrap_or_default()
+            .to_string(),
+          request.headers().get("x-password")
+            .and_then(|v| v.to_str().ok()).unwrap_or_default()
+            .to_string(),
+        ),
         "/platform/login" => login_route(
           &request, platform_store.clone(),
           request.headers().get("x-email")

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -24,6 +24,7 @@ pub use crate::utils::responses::{
 
 pub mod api;
 pub use crate::api::dashboard_route::dashboard_route;
+pub use crate::api::dashboard_login::dashboard_login_route;
 //pub use crate::api::create_event_route::create_event_route;
 pub use crate::api::event_route::event_details_route;
 pub use crate::api::login::login_route;

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -4,6 +4,7 @@ pub mod hooks;
 pub use hooks::use_dashboard_api::use_dashboard_api;
 pub use hooks::use_event::use_event;
 pub use hooks::use_platform_login::use_platform_login;
+pub use hooks::use_dashboard_login::use_dashboard_login;
 
 pub mod components;
 pub use components::toast::Toast;

--- a/frontend/src/pages/login.rs
+++ b/frontend/src/pages/login.rs
@@ -1,5 +1,5 @@
 use dioxus::prelude::*;
-use crate::{Route, BrandContext, use_platform_login, ClientContext, ToastContext};
+use crate::{Route, BrandContext, use_dashboard_login, ClientContext, ToastContext};
 use models::{LoginAttempt};
 
 #[component]
@@ -11,7 +11,7 @@ pub fn Login() -> Element {
   let mut login_attempt = use_signal(|| None);
 
 
-  let user = use_platform_login(
+  let user = use_dashboard_login(
     login_attempt,
     use_context::<Signal<ToastContext>>(),
     use_context::<Signal<ClientContext>>(),

--- a/models/src/dashboard/user.rs
+++ b/models/src/dashboard/user.rs
@@ -50,6 +50,17 @@ impl PartialEq<LoginAttempt> for DashboardUser {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+impl PartialEq<crate::platform::user::LoginAttempt> for DashboardUser {
+  fn eq(&self, attempt: &crate::platform::user::LoginAttempt) -> bool {
+    if self.email != attempt.email {
+      return false;
+    }
+
+    verify_password(&attempt.password, &self.password)
+  }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 impl Patch<DashboardUser> for DashboardUserPatch {
   fn apply_to(self, target: &mut DashboardUser) -> () {
     if let Some(password) = self.password {


### PR DESCRIPTION
## Summary
- implement dashboard_login_route using DashboardStore
- use new dashboard_login_route in backend server
- switch login page to dashboard login hook
- expose use_dashboard_login in frontend
- support dashboard LoginAttempt comparison

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_687ecdb25f1c832b8abbea56bab919f3