### PR TITLE
Implement create-event flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,19 @@ cargo run -p frontend --bin frontend
 
 The backend uses unstable Rust features, so ensure you have the nightly toolchain
 installed (e.g. `rustup default nightly`).
+
+## Running the frontend
+
+The web UI uses Dioxus and needs a few prerequisites for development:
+
+```bash
+cargo install dioxus-cli
+```
+
+Start the application with:
+
+```bash
+dx serve --package frontend
+```
+
+The frontend communicates with the backend over HTTP at `http://localhost:8080`.

--- a/backend/src/api/create_event_route.rs
+++ b/backend/src/api/create_event_route.rs
@@ -16,6 +16,7 @@ pub fn create_event_route(
         image: String::new(),
         banner: None,
         upsell: None,
+        active: false,
     };
     dashboard_store.command(&DashboardCommand::CreateEvent(event.clone()))?;
     dashboard_store.fold()?;

--- a/backend/src/api/dashboard_login.rs
+++ b/backend/src/api/dashboard_login.rs
@@ -1,0 +1,36 @@
+use http::Request;
+use http::Response;
+use http::StatusCode;
+use std::error::Error;
+
+use crate::not_found_route;
+use crate::{DashboardModel, DashboardStore};
+use models::LoginAttempt;
+
+pub fn dashboard_login_route(
+    _req: &Request<()>,
+    dashboard_store: DashboardStore,
+    email: String,
+    password: String,
+) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+    let user = dashboard_store
+        .borrow_inner()
+        .query_owned(format!("user-{}", email.clone()))?;
+
+    let login_attempt = LoginAttempt { email, password };
+
+    match user {
+        Some(DashboardModel::User(user)) if user == login_attempt => {
+            let json = serde_json::to_vec(&user)?;
+
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
+                .body(json)?)
+        }
+        _ => not_found_route(),
+    }
+}

--- a/backend/src/api/dashboard_route.rs
+++ b/backend/src/api/dashboard_route.rs
@@ -10,7 +10,7 @@ use models::{Event};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DashboardApi {
-  pub announcment: String,
+  pub announcement: String,
   pub name: String,
   pub events: Vec<Event>,
 }
@@ -25,7 +25,8 @@ pub fn dashboard_route(
 
   match dashboard {
     Some(DashboardModel::DashboardData(dashboard)) => {
-      let json: Vec<u8> = serde_json::to_vec(&(dashboard + Vec::new()))?;
+      let active = dashboard.events.iter().filter(|e| e.active).cloned().collect();
+      let json: Vec<u8> = serde_json::to_vec(&(dashboard + active))?;
 
       Ok(Response::builder()
         .status(StatusCode::OK)
@@ -40,7 +41,7 @@ pub fn dashboard_route(
 
   /*let dummy_data = DashboardApi {
     name: "Bucket Golf Leagues".to_string(),
-    announcment: "⛳️ New summer leagues of bucket golf just dropped. Rally your crew and start swinging!".to_string(),
+    announcement: "⛳️ New summer leagues of bucket golf just dropped. Rally your crew and start swinging!".to_string(),
     events,
   };*/
 

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -1,5 +1,8 @@
-
 pub mod dashboard_route;
+pub mod dashboard_login;
 pub mod create_event_route;
 pub mod event_route;
 pub mod login;
+pub mod register_event_route;
+pub mod platform_create_route;
+pub mod platform_update_route;

--- a/backend/src/api/platform_create_route.rs
+++ b/backend/src/api/platform_create_route.rs
@@ -1,0 +1,21 @@
+use http::{Request, Response, StatusCode};
+use std::error::Error;
+
+use crate::{PlatformCommand, PlatformStore};
+use models::Platform;
+
+pub fn platform_create_route(
+    req: Request<Vec<u8>>,
+    mut platform_store: PlatformStore,
+) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+    let platform: Platform = serde_json::from_slice(req.body())?;
+    platform_store.command(&PlatformCommand::CreatePlatform(platform))?;
+
+    Ok(Response::builder()
+        .status(StatusCode::CREATED)
+        .header("Content-Type", "application/json")
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "*")
+        .header("Access-Control-Allow-Headers", "*")
+        .body(b"{\"status\":\"created\"}".to_vec())?)
+}

--- a/backend/src/api/platform_update_route.rs
+++ b/backend/src/api/platform_update_route.rs
@@ -1,0 +1,21 @@
+use http::{Request, Response, StatusCode};
+use std::error::Error;
+
+use crate::{PlatformCommand, PlatformStore};
+use models::PlatformPatch;
+
+pub fn platform_update_route(
+    req: Request<Vec<u8>>,
+    mut platform_store: PlatformStore,
+) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+    let patch: PlatformPatch = serde_json::from_slice(req.body())?;
+    platform_store.command(&PlatformCommand::UpdatePlatform(patch))?;
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "application/json")
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "*")
+        .header("Access-Control-Allow-Headers", "*")
+        .body(b"{\"status\":\"updated\"}".to_vec())?)
+}

--- a/backend/src/api/register_event_route.rs
+++ b/backend/src/api/register_event_route.rs
@@ -1,0 +1,32 @@
+use http::{Request, Response, StatusCode};
+use std::error::Error;
+
+use crate::{RegistrationCommand, RegistrationStore};
+use models::Registration;
+
+pub fn register_event_route(
+    _req: &Request<()>,
+    mut store: RegistrationStore,
+    event_id: String,
+    email: String,
+) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+    let registration = Registration {
+        id: format!("{}-{}", event_id, email),
+        event_id,
+        email,
+    };
+
+    store.command(&RegistrationCommand::CreateRegistration(
+        registration.clone(),
+    ))?;
+
+    let json = serde_json::to_vec(&registration)?;
+
+    Ok(Response::builder()
+        .status(StatusCode::CREATED)
+        .header("Content-Type", "application/json")
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "*")
+        .header("Access-Control-Allow-Headers", "*")
+        .body(json)?)
+}

--- a/backend/src/async/tcp_stream.rs
+++ b/backend/src/async/tcp_stream.rs
@@ -1,60 +1,65 @@
-use std::net::TcpStream;
 use std::io::BufReader;
 use std::io::Write;
+use std::net::TcpStream;
 use std::task::LocalWaker;
 use std::time::Duration;
 
-use crate::NetExecutor;
 use crate::AsyncReadLineFuture;
 use crate::AsyncWriteAllFuture;
+use crate::NetExecutor;
 
 #[allow(unused_imports)]
-use log::{error, warn, info, debug, trace};
+use log::{debug, error, info, trace, warn};
 
 pub struct AsyncTcpStream {
-  reader: BufReader<TcpStream>,
-  executor: NetExecutor,
+    reader: BufReader<TcpStream>,
+    executor: NetExecutor,
 }
 
 impl Drop for AsyncTcpStream {
-  fn drop(&mut self) {
-    self.executor.clone().unregister(self.reader.get_ref());
-  }
+    fn drop(&mut self) {
+        self.executor.clone().unregister(self.reader.get_ref());
+    }
 }
 
 impl AsyncTcpStream {
-  pub fn new(stream: TcpStream, executor: NetExecutor) -> Result<Self, Box<dyn std::error::Error>> {
-    trace!("Setting TcpStream to non-blocking");
-    stream.set_nonblocking(true)?;
-    let this = AsyncTcpStream {
-      reader: BufReader::new(stream),
-      executor: executor.clone()
-    };
-    executor.preregister(this.reader.get_ref());
-    Ok(this)
-  }
+    pub fn new(
+        stream: TcpStream,
+        executor: NetExecutor,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        trace!("Setting TcpStream to non-blocking");
+        stream.set_nonblocking(true)?;
+        let this = AsyncTcpStream {
+            reader: BufReader::new(stream),
+            executor: executor.clone(),
+        };
+        executor.preregister(this.reader.get_ref());
+        Ok(this)
+    }
 
-  pub fn set_timeout(&self, duration: Option<Duration>) {
-    self.executor.clone().set_timeout(self.reader.get_ref(), duration)
-  }
+    pub fn set_timeout(&self, duration: Option<Duration>) {
+        self.executor
+            .clone()
+            .set_timeout(self.reader.get_ref(), duration)
+    }
 
-  pub fn register(&self, waker: LocalWaker) {
-    self.executor.clone().register(self.reader.get_ref(), waker)
-  }
+    pub fn register(&self, waker: LocalWaker) {
+        self.executor.clone().register(self.reader.get_ref(), waker)
+    }
 
-  pub fn reader(&mut self) -> &mut BufReader<TcpStream> {
-    &mut self.reader
-  }
+    pub fn reader(&mut self) -> &mut BufReader<TcpStream> {
+        &mut self.reader
+    }
 
-  pub fn read_line(&mut self) -> AsyncReadLineFuture {
-    AsyncReadLineFuture::new(self)
-  }
+    pub fn read_line(&mut self) -> AsyncReadLineFuture<'_> {
+        AsyncReadLineFuture::new(self)
+    }
 
-  pub fn write(&self, buf: &[u8]) -> std::io::Result<usize> {
-    self.reader.get_ref().write(buf)
-  }
+    pub fn write(&self, buf: &[u8]) -> std::io::Result<usize> {
+        self.reader.get_ref().write(buf)
+    }
 
-  pub fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> AsyncWriteAllFuture<'a> {
-    AsyncWriteAllFuture::new(self, buf)
-  }
+    pub fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> AsyncWriteAllFuture<'a> {
+        AsyncWriteAllFuture::new(self, buf)
+    }
 }

--- a/backend/src/bin/backend.rs
+++ b/backend/src/bin/backend.rs
@@ -5,195 +5,236 @@ use std::path::Path;
 
 use backend::PlatformStore;
 use backend::{
-  NetExecutor,
-  AsyncTcpListener,
-  AsyncHttpRequest,
-  dashboard_store,
-  DashboardStore,
-  DashboardCommand,
-  PlatformCommand,
-  platform_store,
+    dashboard_store, platform_store, registration_store, AsyncHttpRequest, AsyncTcpListener,
+    DashboardCommand, DashboardStore, NetExecutor, PlatformCommand,
 };
 
-use models::{
-  Event,
-  Platform,
-  PlatformUser,
-  DashboardUser,
-};
+use models::{DashboardUser, Event, Platform, PlatformUser};
 
 use backend::{
-  not_found_route,
-  error_route,
-  dashboard_route,
-  event_details_route,
-  login_route,
-  api::create_event_route::create_event_route,
+    dashboard_route, error_route, event_details_route, login_route, not_found_route,
+    register_event_route, dashboard_login_route, platform_create_route,
+    platform_update_route, api::create_event_route::create_event_route,
 };
 fn clear_directory(path: &str) -> io::Result<()> {
-  if Path::new(path).exists() {
-    for entry in fs::read_dir(path)? {
-      let entry = entry?;
-      let path = entry.path();
-      if path.is_file() {
-        fs::remove_file(path)?;
-      } else if path.is_dir() {
-        fs::remove_dir_all(path)?;
-      }
+    if Path::new(path).exists() {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file() {
+                fs::remove_file(path)?;
+            } else if path.is_dir() {
+                fs::remove_dir_all(path)?;
+            }
+        }
     }
-  }
-  Ok(())
+    Ok(())
 }
 
 pub fn seed_platform(platform_store: &mut PlatformStore) {
-  let platform = Platform {
-    tenant_id: "bucket-golf".into(),
-    community_name: "Bucket Golf Leagues".into(),
-    community_description: "Join the most exciting bucket golf leagues in the area!".into(),
-    platform_url: "https://bucketgolf.example.com".into(),
-  };
+    let platform = Platform {
+        tenant_id: "bucket-golf".into(),
+        community_name: "Bucket Golf Leagues".into(),
+        community_description: "Join the most exciting bucket golf leagues in the area!".into(),
+        platform_url: "https://bucketgolf.example.com".into(),
+    };
 
-  if let Err(e) = platform_store.command(&PlatformCommand::CreatePlatform(platform.clone())) {
-    eprintln!("Failed to insert platform: {:?}", e);
-  }
+    if let Err(e) = platform_store.command(&PlatformCommand::CreatePlatform(platform.clone())) {
+        eprintln!("Failed to insert platform: {:?}", e);
+    }
 
-  let user = PlatformUser::new(
-    "ryanbruno506@gmail.com".into(),
-    "hashed_password".into(),
-  );
-  if let Err(e) = platform_store.command(&PlatformCommand::CreateUser(user.clone())) {
-    eprintln!("Failed to insert user: {:?}", e);
-  }
+    let user = PlatformUser::new("ryanbruno506@gmail.com".into(), "hashed_password".into());
+    if let Err(e) = platform_store.command(&PlatformCommand::CreateUser(user.clone())) {
+        eprintln!("Failed to insert user: {:?}", e);
+    }
 
-  println!("✅ Platform seeded.");
+    println!("✅ Platform seeded.");
 }
 
 pub fn seed_example_events(dashboard_store: &mut DashboardStore) {
-  let examples = vec![
-    Event {
-      tenant_id: "bucket-golf".into(),
-      id: "1".into(),
-      name: "Arlington Bucket Golf League".into(),
-      location: "Quincy Park, VA".into(),
-      date: "Saturday, July 13 – 3:00 PM".into(),
-      image: "/static/bucket-golf.jpg".into(),
-      banner: Some("⚡ Almost Sold Out".into()),
-      upsell: Some("Only 3 slots left".into()),
-    },
-    Event {
-      tenant_id: "bucket-golf".into(),
-      id: "2".into(),
-      name: "Launch Meetup".into(),
-      location: "Liberty Park, DC".into(),
-      date: "Monday, July 15 – 5:00 PM".into(),
-      image: "/static/launch-meetup.jpg".into(),
-      banner: None,
-      upsell: None,
-    },
-    Event {
-      tenant_id: "bucket-golf".into(),
-      id: "3".into(),
-      name: "Weekly Planning Session".into(),
-      location: "National Mall, DC".into(),
-      date: "Wednesday, July 17 – 12:00 PM".into(),
-      image: "/static/planning.jpg".into(),
-      banner: Some("🆕 New".into()),
-      upsell: Some("Limited spots available".into()),
-    },
-  ];
+    let examples = vec![
+        Event {
+            tenant_id: "bucket-golf".into(),
+            id: "1".into(),
+            name: "Arlington Bucket Golf League".into(),
+            location: "Quincy Park, VA".into(),
+            date: "Saturday, July 13 – 3:00 PM".into(),
+            image: "/static/bucket-golf.jpg".into(),
+            banner: Some("⚡ Almost Sold Out".into()),
+            upsell: Some("Only 3 slots left".into()),
+            active: false,
+        },
+        Event {
+            tenant_id: "bucket-golf".into(),
+            id: "2".into(),
+            name: "Launch Meetup".into(),
+            location: "Liberty Park, DC".into(),
+            date: "Monday, July 15 – 5:00 PM".into(),
+            image: "/static/launch-meetup.jpg".into(),
+            banner: None,
+            upsell: None,
+            active: false,
+        },
+        Event {
+            tenant_id: "bucket-golf".into(),
+            id: "3".into(),
+            name: "Weekly Planning Session".into(),
+            location: "National Mall, DC".into(),
+            date: "Wednesday, July 17 – 12:00 PM".into(),
+            image: "/static/planning.jpg".into(),
+            banner: Some("🆕 New".into()),
+            upsell: Some("Limited spots available".into()),
+            active: false,
+        },
+    ];
 
-  for event in examples {
-    if let Err(e) = dashboard_store.command(&DashboardCommand::CreateEvent(event.clone())) {
-      eprintln!("Failed to insert event {:?}: {:?}", event.name, e);
+    for event in examples {
+        if let Err(e) = dashboard_store.command(&DashboardCommand::CreateEvent(event.clone())) {
+            eprintln!("Failed to insert event {:?}: {:?}", event.name, e);
+        }
     }
-  }
 
-  let user = DashboardUser::new(
-    "ryanbruno506@gmail.com".into(),
-    "hashed_password".into(),
-  );
-  if let Err(e) = dashboard_store.command(&DashboardCommand::CreateUser(user.clone())) {
-    eprintln!("Failed to insert user: {:?}", e);
-  }
+    let user = DashboardUser::new("ryanbruno506@gmail.com".into(), "hashed_password".into());
+    if let Err(e) = dashboard_store.command(&DashboardCommand::CreateUser(user.clone())) {
+        eprintln!("Failed to insert user: {:?}", e);
+    }
 
-  dashboard_store.command(&DashboardCommand::SetName((
-    "bucket-golf".into(),
-    "Bucket Golf Leagues".into(),
-  ))).unwrap();
+    dashboard_store
+        .command(&DashboardCommand::SetName((
+            "bucket-golf".into(),
+            "Bucket Golf Leagues".into(),
+        )))
+        .unwrap();
 
-  dashboard_store.command(&DashboardCommand::SetAnnouncement((
+    dashboard_store.command(&DashboardCommand::SetAnnouncement((
     "bucket-golf".into(),
     "⛳️ New summer leagues of bucket golf just dropped. Rally your crew and start swinging!".into(),
   ))).unwrap();
 
-  println!("✅ Example events seeded.");
+    println!("✅ Example events seeded.");
 }
 
-
 #[allow(unused_imports)]
-use log::{error, warn, info, debug, trace};
+use log::{debug, error, info, trace, warn};
 
-pub fn main() -> Result<(), Box<dyn Error>>{
-  log4rs::init_file("log4rs.yml", Default::default()).unwrap();
+pub fn main() -> Result<(), Box<dyn Error>> {
+    log4rs::init_file("log4rs.yml", Default::default()).unwrap();
 
-  /* Clear and seed data for development */
-  clear_directory("data/")?;
-  let mut dashboard_store = dashboard_store()?;
-  let mut platform_store = platform_store()?;
-  seed_example_events(&mut dashboard_store);
-  seed_platform(&mut platform_store);
-  dashboard_store.fold()?;
-  platform_store.fold()?;
+    /* Clear and seed data for development */
+    clear_directory("data/")?;
+    let mut dashboard_store = dashboard_store()?;
+    let mut platform_store = platform_store()?;
+    let mut registration_store = registration_store()?;
+    seed_example_events(&mut dashboard_store);
+    seed_platform(&mut platform_store);
+    dashboard_store.fold()?;
+    platform_store.fold()?;
+    registration_store.fold()?;
 
-  /* Start the server */
-  let executor = NetExecutor::new();
-  let listener = AsyncTcpListener::new(8000, executor.clone()).unwrap();
-  let server = AsyncHttpRequest::new(listener, executor.clone());
+    /* Start the server */
+    let executor = NetExecutor::new();
+    let listener = AsyncTcpListener::new(8000, executor.clone()).unwrap();
+    let server = AsyncHttpRequest::new(listener, executor.clone());
 
-  executor.clone().spawn(async move {
-    loop {
-      /* Wait for a new request */
-      let (request, mut stream) = server.next_request().await.unwrap();
+    executor.clone().spawn(async move {
+        loop {
+            /* Wait for a new request */
+            let (request, mut stream) = server.next_request().await.unwrap();
 
-      /* Process the request */
-      let response = match request.uri().path() {
-        "/dashboard" => dashboard_route(
-          &request, dashboard_store.clone(),
-          request.headers().get("x-tenant_id")
-            .and_then(|v| v.to_str().ok()).unwrap_or_default()
-            .to_string(),
-        ),
-        "/dashboard/event" => event_details_route(
-          &request, dashboard_store.clone(),
-          request.headers().get("x-id")
-            .and_then(|v| v.to_str().ok()).unwrap_or_default()
-            .to_string()
-        ),
-        "/dashboard/login" => panic!(),
-        "/platform/login" => login_route(
-          &request, platform_store.clone(),
-          request.headers().get("x-email")
-            .and_then(|v| v.to_str().ok()).unwrap_or_default()
-            .to_string(),
-          request.headers().get("x-password")
-            .and_then(|v| v.to_str().ok()).unwrap_or_default()
-            .to_string(),
-        ),
-        "/create-event" => create_event_route(
-          &request, dashboard_store.clone(),
-        ),
+            /* Process the request */
+            let response = match request.uri().path() {
+                "/dashboard" => dashboard_route(
+                    &request,
+                    dashboard_store.clone(),
+                    request
+                        .headers()
+                        .get("x-tenant_id")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                ),
+                "/dashboard/event" => event_details_route(
+                    &request,
+                    dashboard_store.clone(),
+                    request
+                        .headers()
+                        .get("x-id")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                ),
+                "/dashboard/register_event" => register_event_route(
+                    &request,
+                    registration_store.clone(),
+                    request
+                        .headers()
+                        .get("x-id")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                    request
+                        .headers()
+                        .get("x-email")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("guest@example.com")
+                        .to_string(),
+                ),
+                "/dashboard/login" => dashboard_login_route(
+                    &request,
+                    dashboard_store.clone(),
+                    request
+                        .headers()
+                        .get("x-email")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                    request
+                        .headers()
+                        .get("x-password")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                ),
+                "/platform/login" => login_route(
+                    &request,
+                    platform_store.clone(),
+                    request
+                        .headers()
+                        .get("x-email")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                    request
+                        .headers()
+                        .get("x-password")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                ),
+                "/create-event" => create_event_route(
+                    &request,
+                    dashboard_store.clone(),
+                ),
+                "/platform/create" => platform_create_route(
+                    http::Request::builder().body(Vec::new()).unwrap(),
+                    platform_store.clone(),
+                ),
+                "/platform/update" => platform_update_route(
+                    http::Request::builder().body(Vec::new()).unwrap(),
+                    platform_store.clone(),
+                ),
+                _ => not_found_route(),
+            }
+            .unwrap_or_else(|e| {
+                error!("Error processing request: {e}");
+                error_route()
+            });
 
-        _ => not_found_route(),
-      }.unwrap_or_else(|e| {
-        error!("Error processing request: {e}");
-        error_route()
-      });
+            /* Write the response back to the client */
+            AsyncHttpRequest::write_response(&mut stream, response).await;
+        }
+    });
 
-      /* Write the response back to the client */
-      AsyncHttpRequest::write_response(&mut stream, response).await;
-    }
-  });
-
-  executor.run();
-  Ok(())
+    executor.run();
+    Ok(())
 }

--- a/backend/src/executor/net_executor.rs
+++ b/backend/src/executor/net_executor.rs
@@ -1,147 +1,223 @@
-use std::task::ContextBuilder;
-use std::time::Instant;
-use std::time::Duration;
-use std::task::LocalWaker;
-use std::cell::RefCell;
-use std::future::Future;
-use std::rc::Rc;
-use std::os::fd::AsRawFd;
-use std::task::Waker;
-use polling::{Event, Events, Poller};
-use polling::AsSource;
 use polling::AsRawSource;
+use polling::AsSource;
+use polling::{Event, Events, Poller};
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::future::Future;
+use std::os::fd::AsRawFd;
+use std::rc::Rc;
+use std::task::ContextBuilder;
+use std::task::LocalWaker;
+use std::task::Waker;
+use std::time::Duration;
+use std::time::Instant;
 
 #[allow(unused_imports)]
-use log::{error, warn, info, debug, trace};
+use log::{debug, error, info, trace, warn};
 
 use crate::NetTask;
 
 //#[derive(Default)]
 struct NetExecutorInner {
-  poller: Poller,
-  map: HashMap<usize, LocalWaker>,
-  queue: Vec<NetTask>,
-  timeouts: HashMap<usize, (Instant, Duration)>,
+    poller: Poller,
+    map: HashMap<usize, LocalWaker>,
+    queue: Vec<NetTask>,
+    timeouts: HashMap<usize, (Instant, Duration)>,
 }
 
 #[derive(Clone)]
 pub struct NetExecutor(Rc<RefCell<NetExecutorInner>>);
 
 impl Default for NetExecutor {
-  fn default() -> Self {
-    Self::new()
-  }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl NetExecutor {
-  pub fn new() -> Self {
-    NetExecutor(Rc::new(RefCell::new(NetExecutorInner {
-      poller: Poller::new().unwrap(),
-      map: HashMap::new(),
-      queue: Vec::new(),
-      timeouts: HashMap::new(),
-    })))
-  }
-
-  pub fn set_timeout(self, fd: impl AsSource, time: Option<Duration>) {
-    match time {
-      Some(d) => {
-        self.0.borrow_mut().timeouts.insert(fd.source().as_raw_fd().try_into().unwrap(), (Instant::now(), d));
-      },
-      None => {
-        self.0.borrow_mut().timeouts.remove(&fd.source().as_raw_fd().try_into().unwrap());
-      },
+    pub fn new() -> Self {
+        NetExecutor(Rc::new(RefCell::new(NetExecutorInner {
+            poller: Poller::new().unwrap(),
+            map: HashMap::new(),
+            queue: Vec::new(),
+            timeouts: HashMap::new(),
+        })))
     }
 
-  }
-
-  pub fn enqueue(self, task: NetTask) {
-    trace!("Queueing Task");
-    self.0.borrow_mut().queue.push(task);
-    trace!("Queued Task");
-  }
-
-  pub fn preregister(self, raw: impl AsRawSource) {
-    let fd: usize = raw.raw().try_into().unwrap();
-
-    unsafe {
-      self.0.borrow().poller.add(raw, Event::none(fd)).unwrap();
-      trace!("Added fd #{fd} to Poller");
-    }
-  }
-
-  pub fn unregister(self, raw: impl AsSource) {
-    let fd: usize = raw.source().as_raw_fd().try_into().unwrap();
-    trace!("Unregistering fd #{fd} from poller");
-    self.0.borrow().poller.delete(&raw).unwrap();
-    self.set_timeout(raw, None);
-  }
-
-  pub fn register(self, raw: impl AsSource, waker: LocalWaker) {
-    let fd: usize = raw.source().as_raw_fd().try_into().unwrap();
-    trace!("Registering fd #{fd} with NetExecutor");
-    self.0.borrow_mut().map.insert(fd, waker);
-    trace!("Added fd #{fd} to NetExecutor's Map");
-
-    self.0.borrow().poller.modify(raw, Event::readable(fd)).unwrap();
-    trace!("Added fd #{fd} to Poller");
-  }
-
-  pub fn spawn(self, future: impl Future<Output = ()> + 'static) {
-    let future = Box::pin(future);
-    trace!("Spawning task with NetExecutor");
-    let task = NetTask::new(future, self.clone());
-    self.enqueue(task);
-    trace!("Added task to NetExecutor's queue");
-  }
-
-  pub fn run(self) {
-    loop {
-      loop {
-        let mut queue = std::mem::take(&mut self.0.borrow_mut().queue);
-        let queue_size = queue.len();
-        if queue_size == 0 { break }
-
-        trace!("Starting NetExecutor loop with {queue_size} tasks");
-        for task in queue.drain(0..) {
-          let task: Rc<NetTask> = Rc::new(task);
-          let _ = unsafe { task.poll(&mut ContextBuilder::from_waker(Waker::noop())
-            .local_waker(&task.clone().into())
-            .build()) } ;
+    pub fn set_timeout(self, fd: impl AsSource, time: Option<Duration>) {
+        match time {
+            Some(d) => {
+                self.0.borrow_mut().timeouts.insert(
+                    fd.source().as_raw_fd().try_into().unwrap(),
+                    (Instant::now(), d),
+                );
+            }
+            None => {
+                self.0
+                    .borrow_mut()
+                    .timeouts
+                    .remove(&fd.source().as_raw_fd().try_into().unwrap());
+            }
         }
-      }
-
-      trace!("Polling");
-      let events = {
-        let mut events = Events::new();
-        self.0.borrow().poller.wait(&mut events, Some(Duration::new(100000, 0))).unwrap();
-        events
-      };
-      let events_len = events.len();
-      trace!("Recieved {events_len} events from Poller");
-      for event in events.iter() {
-        let fd = event.key;
-        trace!("Recieved an event from Poller {event:?}");
-        let waker = self.0.borrow_mut().map.remove(&fd).unwrap();
-        waker.wake();
-        trace!("Called wake on fd #{fd}");
-      }
-
-      trace!("Reviewing timeouts");
-      let timeouts = self.0.borrow().timeouts.iter()
-        .filter_map(|(k, (i, d))|
-          match i.elapsed() > *d {
-            true => Some(*k),
-            false => None,
-        })
-        .collect::<Vec<usize>>();
-
-      let timeouts_len = timeouts.len();
-      trace!("Timing out {timeouts_len} fds");
-      let _ = timeouts.iter()
-        .filter_map(|fd| self.0.borrow_mut().map.remove(fd))
-        .collect::<Vec<LocalWaker>>();
     }
-  }
+
+    pub fn enqueue(self, task: NetTask) {
+        trace!("Queueing Task");
+        self.0.borrow_mut().queue.push(task);
+        trace!("Queued Task");
+    }
+
+    pub fn preregister(self, raw: impl AsRawSource) {
+        let fd: usize = raw.raw().try_into().unwrap();
+
+        unsafe {
+            self.0.borrow().poller.add(raw, Event::none(fd)).unwrap();
+            trace!("Added fd #{fd} to Poller");
+        }
+    }
+
+    pub fn unregister(self, raw: impl AsSource) {
+        let fd: usize = raw.source().as_raw_fd().try_into().unwrap();
+        trace!("Unregistering fd #{fd} from poller");
+        self.0.borrow().poller.delete(&raw).unwrap();
+        self.set_timeout(raw, None);
+    }
+
+    pub fn register(self, raw: impl AsSource, waker: LocalWaker) {
+        let fd: usize = raw.source().as_raw_fd().try_into().unwrap();
+        trace!("Registering fd #{fd} with NetExecutor");
+        self.0.borrow_mut().map.insert(fd, waker);
+        trace!("Added fd #{fd} to NetExecutor's Map");
+
+        self.0
+            .borrow()
+            .poller
+            .modify(raw, Event::readable(fd))
+            .unwrap();
+        trace!("Added fd #{fd} to Poller");
+    }
+
+    pub fn spawn(self, future: impl Future<Output = ()> + 'static) {
+        let future = Box::pin(future);
+        trace!("Spawning task with NetExecutor");
+        let task = NetTask::new(future, self.clone());
+        self.enqueue(task);
+        trace!("Added task to NetExecutor's queue");
+    }
+
+    pub fn run(self) {
+        loop {
+            loop {
+                let mut queue = std::mem::take(&mut self.0.borrow_mut().queue);
+                let queue_size = queue.len();
+                if queue_size == 0 {
+                    break;
+                }
+
+                trace!("Starting NetExecutor loop with {queue_size} tasks");
+                for task in queue.drain(0..) {
+                    let task: Rc<NetTask> = Rc::new(task);
+                    let _ = unsafe {
+                        task.poll(
+                            &mut ContextBuilder::from_waker(Waker::noop())
+                                .local_waker(&task.clone().into())
+                                .build(),
+                        )
+                    };
+                }
+            }
+
+            trace!("Polling");
+            let events = {
+                let mut events = Events::new();
+                self.0
+                    .borrow()
+                    .poller
+                    .wait(&mut events, Some(Duration::new(100000, 0)))
+                    .unwrap();
+                events
+            };
+            let events_len = events.len();
+            trace!("Recieved {events_len} events from Poller");
+            for event in events.iter() {
+                let waker = {
+                    let mut inner = self.0.borrow_mut();
+                    inner.map.remove(&event.key)
+                };
+                if let Some(waker) = waker {
+                    waker.wake();
+                }
+            }
+
+            trace!("Reviewing timeouts");
+            let timeouts = self
+                .0
+                .borrow()
+                .timeouts
+                .iter()
+                .filter_map(|(k, (i, d))| match i.elapsed() > *d {
+                    true => Some(*k),
+                    false => None,
+                })
+                .collect::<Vec<usize>>();
+
+            let timeouts_len = timeouts.len();
+            trace!("Timing out {timeouts_len} fds");
+            let _ = timeouts
+                .iter()
+                .filter_map(|fd| self.0.borrow_mut().map.remove(fd))
+                .collect::<Vec<LocalWaker>>();
+        }
+    }
+
+    pub fn run_for(&self, duration: Duration) {
+        let start = Instant::now();
+        while start.elapsed() < duration {
+            loop {
+                let mut queue = std::mem::take(&mut self.0.borrow_mut().queue);
+                if queue.is_empty() {
+                    break;
+                }
+                for task in queue.drain(0..) {
+                    let task: Rc<NetTask> = Rc::new(task);
+                    let _ = unsafe {
+                        task.poll(
+                            &mut ContextBuilder::from_waker(Waker::noop())
+                                .local_waker(&task.clone().into())
+                                .build(),
+                        )
+                    };
+                }
+            }
+
+            let mut events = Events::new();
+            self.0
+                .borrow()
+                .poller
+                .wait(&mut events, Some(Duration::from_millis(10)))
+                .unwrap();
+
+            for event in events.iter() {
+                let waker = {
+                    let mut inner = self.0.borrow_mut();
+                    inner.map.remove(&event.key)
+                };
+                if let Some(waker) = waker {
+                    waker.wake();
+                }
+            }
+
+            let timeouts = self
+                .0
+                .borrow()
+                .timeouts
+                .iter()
+                .filter_map(|(k, (i, d))| if i.elapsed() > *d { Some(*k) } else { None })
+                .collect::<Vec<usize>>();
+
+            for fd in timeouts {
+                self.0.borrow_mut().map.remove(&fd);
+            }
+        }
+    }
 }

--- a/backend/src/futures/read_line.rs
+++ b/backend/src/futures/read_line.rs
@@ -1,45 +1,81 @@
-use std::task::Poll;
-use std::task::Context;
-use std::pin::Pin;
-use std::future::Future;
-use std::io::ErrorKind;
 use std::error::Error;
+use std::future::Future;
+use std::io::{BufRead, ErrorKind};
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
 use std::task::Poll::Ready;
-use std::io::BufRead;
 
 use crate::AsyncTcpStream;
 
 #[allow(unused_imports)]
-use log::{error, warn, info, debug, trace};
+use log::{debug, error, info, trace, warn};
 
 pub struct AsyncReadLineFuture<'a> {
-  stream: &'a mut AsyncTcpStream,
+    stream: &'a mut AsyncTcpStream,
+    buf: String,
 }
 impl<'a> AsyncReadLineFuture<'a> {
-  pub fn new(stream: &'a mut AsyncTcpStream) -> Self {
-    AsyncReadLineFuture { stream }
-  }
+    pub fn new(stream: &'a mut AsyncTcpStream) -> Self {
+        AsyncReadLineFuture {
+            stream,
+            buf: String::new(),
+        }
+    }
 }
 impl Future for AsyncReadLineFuture<'_> {
     type Output = Result<String, Box<dyn Error>>;
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
-      trace!("Poll called for AsyncReadLineFuture");
-      let reader = self.stream.reader();
-      let mut buffer = String::new();
+        trace!("Poll called for AsyncReadLineFuture");
 
-      // TODO this blocks :(
-      match reader.read_line(&mut buffer) {
-        Ok(_) => {
-          trace!("Poll read a line {buffer}");
-          Ready(Ok(buffer))
-        },
-        Err(e) if e.kind() == ErrorKind::WouldBlock => {
-          trace!("Poll returned WouldBlock");
-          self.stream.register(ctx.local_waker().clone());
-          Poll::Pending
-        },
-        Err(e) => Ready(Err(Box::new(e))),
-      }
+        loop {
+            let mut local = std::mem::take(&mut self.buf);
+            let mut consume = 0usize;
+            let mut complete = false;
+
+            {
+                let reader = self.stream.reader();
+                match reader.fill_buf() {
+                    Ok(buf) if buf.is_empty() => {
+                        complete = true;
+                    }
+                    Ok(buf) => {
+                        if let Some(pos) = buf.iter().position(|b| *b == b'\n') {
+                            let slice = &buf[..=pos];
+                            local.push_str(
+                                std::str::from_utf8(slice)
+                                    .map_err(|e| Box::new(e) as Box<dyn Error>)?,
+                            );
+                            consume = pos + 1;
+                            complete = true;
+                        } else {
+                            local.push_str(
+                                std::str::from_utf8(buf)
+                                    .map_err(|e| Box::new(e) as Box<dyn Error>)?,
+                            );
+                            consume = buf.len();
+                        }
+                    }
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                        self.buf = local;
+                        self.stream.register(ctx.local_waker().clone());
+                        return Poll::Pending;
+                    }
+                    Err(e) => return Ready(Err(Box::new(e))),
+                }
+            }
+
+            if consume > 0 {
+                self.stream.reader().consume(consume);
+            }
+
+            if complete {
+                trace!("Poll read a line {local}");
+                return Ready(Ok(local));
+            } else {
+                self.buf = local;
+            }
+        }
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,37 +1,42 @@
 #![feature(local_waker)]
 
 mod executor;
+pub use crate::executor::BoxFuture;
 pub use crate::executor::NetExecutor;
 pub use crate::executor::NetTask;
-pub use crate::executor::BoxFuture;
 mod r#async;
+pub use crate::r#async::AsyncHttpRequest;
 pub use crate::r#async::AsyncTcpListener;
 pub use crate::r#async::AsyncTcpStream;
-pub use crate::r#async::AsyncHttpRequest;
 mod futures;
-pub use crate::futures::AsyncTcpStreamFuture;
 pub use crate::futures::AsyncReadLineFuture;
+pub use crate::futures::AsyncTcpStreamFuture;
 pub use crate::futures::AsyncWriteAllFuture;
 
 mod utils;
-pub use crate::utils::channel::{Receiver, Sender, channel};
+pub use crate::utils::channel::{channel, Receiver, Sender};
 pub use crate::utils::error::GenericError;
-pub use crate::utils::responses::{
-    serve_route,
-    not_found_route,
-    error_route,
-};
+pub use crate::utils::responses::{error_route, not_found_route, serve_route};
 
 pub mod api;
 pub use crate::api::dashboard_route::dashboard_route;
+pub use crate::api::dashboard_login::dashboard_login_route;
 //pub use crate::api::create_event_route::create_event_route;
 pub use crate::api::event_route::event_details_route;
 pub use crate::api::login::login_route;
+pub use crate::api::register_event_route::register_event_route;
+pub use crate::api::platform_create_route::platform_create_route;
+pub use crate::api::platform_update_route::platform_update_route;
 
 pub mod database;
-pub use crate::database::kv_store::KVStore;
 pub use crate::database::cqrs_store::{CQRSStore, Command};
+pub use crate::database::kv_store::KVStore;
 
 pub mod store;
-pub use crate::store::dashboard::{DashboardCommand, DashboardModel, DashboardStore, dashboard_store};
-pub use crate::store::platform::{PlatformCommand, PlatformModel, PlatformStore, platform_store};
+pub use crate::store::dashboard::{
+    dashboard_store, DashboardCommand, DashboardModel, DashboardStore,
+};
+pub use crate::store::dashboard::{
+    registration_store, RegistrationCommand, RegistrationModel, RegistrationStore,
+};
+pub use crate::store::platform::{platform_store, PlatformCommand, PlatformModel, PlatformStore};

--- a/backend/src/store/dashboard.rs
+++ b/backend/src/store/dashboard.rs
@@ -1,152 +1,274 @@
-use std::error::Error;
-use crate::{
-  CQRSStore, Command, KVStore
-};
+use crate::{CQRSStore, Command, KVStore};
 use models::{
-  Event,
-  EventPatch,
-  Patch,
-  EntityId,
-  DashboardData,
-  DashboardUser, DashboardUserPatch
+    DashboardData, DashboardUser, DashboardUserPatch, EntityId, Event, EventPatch, Patch,
+    Registration, RegistrationPatch,
 };
-use rkyv::{
-    Archive, Deserialize, Serialize,
-};
+use rkyv::{Archive, Deserialize, Serialize};
+use std::error::Error;
 
-use std::rc::Rc;
-use std::cell::RefCell;
 use std::cell::Ref;
+use std::cell::RefCell;
+use std::rc::Rc;
 
 #[derive(Default, Clone, Archive, Serialize, Deserialize)]
 pub enum DashboardCommand {
-  #[default]
-  Noop,
-  /* Events */
-  CreateEvent(Event),
-  UpdateEvent((String, EntityId, EventPatch)),
+    #[default]
+    Noop,
+    /* Events */
+    CreateEvent(Event),
+    UpdateEvent((String, EntityId, EventPatch)),
+    StartEvent((String, EntityId)),
+    EndEvent((String, EntityId)),
 
-  /* User */
-  CreateUser(DashboardUser),
-  UpdateUser((String, DashboardUserPatch)),
-  /* Dashboard Info */
-  SetAnnouncement((EntityId, String)),
-  SetName((EntityId, String)),
+    /* User */
+    CreateUser(DashboardUser),
+    UpdateUser((String, DashboardUserPatch)),
+    /* Dashboard Info */
+    SetAnnouncement((EntityId, String)),
+    SetName((EntityId, String)),
 }
 
 #[derive(Default, Clone, Archive, Serialize, Deserialize)]
 pub enum DashboardModel {
-  #[default]
-  Noop,
-  DashboardData(DashboardData),
-  Event(Event),
-  User(DashboardUser),
+    #[default]
+    Noop,
+    DashboardData(DashboardData),
+    Event(Event),
+    User(DashboardUser),
+}
+
+#[derive(Default, Clone, Archive, Serialize, Deserialize)]
+pub enum RegistrationCommand {
+    #[default]
+    Noop,
+    CreateRegistration(Registration),
+    UpdateRegistration((EntityId, RegistrationPatch)),
+}
+
+#[derive(Default, Clone, Archive, Serialize, Deserialize)]
+pub enum RegistrationModel {
+    #[default]
+    Noop,
+    Registration(Registration),
 }
 
 impl Patch<DashboardModel> for DashboardCommand {
-  fn apply_to(self, target: &mut DashboardModel) -> () {
-    match (self, target) {
-      (DashboardCommand::CreateEvent(event), DashboardModel::DashboardData(view)) => {
-        // Add Event to dashboard view
-        view.events.retain(|e| e.id != event.id);
-        view.events.push(event.clone());
-      },
-      (DashboardCommand::CreateEvent(event), target) => {
-        // Create a new dashboard view with the event
-        *target = DashboardModel::DashboardData(DashboardData {
-          announcement: String::new(),
-          name: String::new(),
-          events: vec![event.clone()],
-        });
-      },
-      (DashboardCommand::UpdateEvent((_tenant_id, _id, patch)), DashboardModel::Event(event)) => {
-        // Apply patch to event
-        patch.apply_to(event);
-      },
-      (DashboardCommand::UpdateEvent((_tenant_id, id, patch)), DashboardModel::DashboardData(view)) => {
-        // Apply patch to event
-        patch.apply_to(view.events.iter_mut().find(|e| e.id == id).unwrap());
-      },
-      (DashboardCommand::SetAnnouncement((_tenant_id, announcement)), DashboardModel::DashboardData(view)) => {
-        // Set announcement in dashboard view
-        view.announcement = announcement;
-      },
-      (DashboardCommand::SetName((_tenant_id, name)), DashboardModel::DashboardData(view)) => {
-        // Set name in dashboard view
-        view.name = name;
-      },
-      _ => {},
+    fn apply_to(self, target: &mut DashboardModel) -> () {
+        match (self, target) {
+            (DashboardCommand::CreateEvent(event), DashboardModel::DashboardData(view)) => {
+                // Add Event to dashboard view
+                view.events.retain(|e| e.id != event.id);
+                view.events.push(event.clone());
+            }
+            (DashboardCommand::CreateEvent(event), target) => {
+                // Create a new dashboard view with the event
+                *target = DashboardModel::DashboardData(DashboardData {
+                    announcement: String::new(),
+                    name: String::new(),
+                    events: vec![event.clone()],
+                });
+            }
+            (
+                DashboardCommand::UpdateEvent((_tenant_id, _id, patch)),
+                DashboardModel::Event(event),
+            ) => {
+                // Apply patch to event
+                patch.apply_to(event);
+            }
+            (DashboardCommand::StartEvent((_, id)), DashboardModel::Event(event)) => {
+              if event.id == id { event.active = true; }
+            },
+            (DashboardCommand::EndEvent((_, id)), DashboardModel::Event(event)) => {
+              if event.id == id { event.active = false; }
+            },
+            (DashboardCommand::StartEvent((_, id)), DashboardModel::DashboardData(view)) => {
+              if let Some(e) = view.events.iter_mut().find(|e| e.id == id) {
+                e.active = true;
+              }
+            },
+            (DashboardCommand::EndEvent((_, id)), DashboardModel::DashboardData(view)) => {
+              if let Some(e) = view.events.iter_mut().find(|e| e.id == id) {
+                e.active = false;
+              }
+            },
+            (
+                DashboardCommand::UpdateEvent((_tenant_id, id, patch)),
+                DashboardModel::DashboardData(view),
+            ) => {
+                // Apply patch to event
+                patch.apply_to(view.events.iter_mut().find(|e| e.id == id).unwrap());
+            }
+            (
+                DashboardCommand::SetAnnouncement((_tenant_id, announcement)),
+                DashboardModel::DashboardData(view),
+            ) => {
+                // Set announcement in dashboard view
+                view.announcement = announcement;
+            }
+            (
+                DashboardCommand::SetName((_tenant_id, name)),
+                DashboardModel::DashboardData(view),
+            ) => {
+                // Set name in dashboard view
+                view.name = name;
+            }
+            _ => {}
+        }
     }
-  }
 }
 
 impl Command<DashboardModel, DashboardCommand> for DashboardCommand {
-  fn fold(&self, kv_store: &mut KVStore<DashboardModel, DashboardCommand>) -> Result<(), Box<dyn Error>> {
-    match self {
-      DashboardCommand::CreateEvent(event) => {
-        /* Create Event */
-        kv_store.create(event.id.clone(), DashboardModel::Event(event.clone()))?;
-        /* Update Tenant's Dashboard */
-        kv_store.update(event.tenant_id.clone(), self.clone())?;
-      },
-      DashboardCommand::UpdateEvent((tenant_id, id, _patch)) => {
-        /* Update Event */
-        kv_store.update(id.clone(), self.clone())?;
-        /* Update Tenant's Dashboard */
-        kv_store.update(tenant_id.clone(), self.clone())?;
-      },
-      DashboardCommand::SetAnnouncement((tenant_id, _announcement)) => {
-        kv_store.update(tenant_id.clone(), self.clone())?;
-      },
-      DashboardCommand::SetName((tenant_id, _name)) => {
-        kv_store.update(tenant_id.clone(), self.clone())?;
-      },
-      DashboardCommand::CreateUser(user) => {
-        /* Create User */
-        kv_store.create(format!("user-{}", user.email),DashboardModel::User(user.clone()))?;
-      },
-      DashboardCommand::UpdateUser((email, _user)) => {
-        /* Update User */
-        kv_store.update(format!("user-{}", email), self.clone())?;
-      },
-      DashboardCommand::Noop => {},
+    fn fold(
+        &self,
+        kv_store: &mut KVStore<DashboardModel, DashboardCommand>,
+    ) -> Result<(), Box<dyn Error>> {
+        match self {
+            DashboardCommand::CreateEvent(event) => {
+                /* Create Event */
+                kv_store.create(event.id.clone(), DashboardModel::Event(event.clone()))?;
+                /* Update Tenant's Dashboard */
+                kv_store.update(event.tenant_id.clone(), self.clone())?;
+            }
+            DashboardCommand::UpdateEvent((tenant_id, id, _patch)) => {
+                /* Update Event */
+                kv_store.update(id.clone(), self.clone())?;
+                /* Update Tenant's Dashboard */
+                kv_store.update(tenant_id.clone(), self.clone())?;
+            }
+            DashboardCommand::StartEvent((tenant_id, id)) | DashboardCommand::EndEvent((tenant_id, id)) => {
+              kv_store.update(id.clone(), self.clone())?;
+              kv_store.update(tenant_id.clone(), self.clone())?;
+            },
+            DashboardCommand::SetAnnouncement((tenant_id, _announcement)) => {
+                kv_store.update(tenant_id.clone(), self.clone())?;
+            }
+            DashboardCommand::SetName((tenant_id, _name)) => {
+                kv_store.update(tenant_id.clone(), self.clone())?;
+            }
+            DashboardCommand::CreateUser(user) => {
+                /* Create User */
+                kv_store.create(
+                    format!("user-{}", user.email),
+                    DashboardModel::User(user.clone()),
+                )?;
+            }
+            DashboardCommand::UpdateUser((email, _user)) => {
+                /* Update User */
+                kv_store.update(format!("user-{}", email), self.clone())?;
+            }
+            DashboardCommand::Noop => {}
+        }
+        Ok(())
     }
-    Ok(())
-  }
+}
+
+impl Patch<RegistrationModel> for RegistrationCommand {
+    fn apply_to(self, target: &mut RegistrationModel) {
+        match (self, target) {
+            (RegistrationCommand::CreateRegistration(r), RegistrationModel::Registration(t)) => {
+                *t = r;
+            }
+            (
+                RegistrationCommand::UpdateRegistration((_id, patch)),
+                RegistrationModel::Registration(t),
+            ) => {
+                patch.apply_to(t);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Command<RegistrationModel, RegistrationCommand> for RegistrationCommand {
+    fn fold(
+        &self,
+        kv_store: &mut KVStore<RegistrationModel, RegistrationCommand>,
+    ) -> Result<(), Box<dyn Error>> {
+        match self {
+            RegistrationCommand::CreateRegistration(reg) => {
+                kv_store.create(reg.id.clone(), RegistrationModel::Registration(reg.clone()))?;
+            }
+            RegistrationCommand::UpdateRegistration((id, _patch)) => {
+                kv_store.update(id.clone(), self.clone())?;
+            }
+            RegistrationCommand::Noop => {}
+        }
+        Ok(())
+    }
 }
 
 pub type DashboardStoreInner = CQRSStore<DashboardCommand, DashboardModel, DashboardCommand>;
 #[derive(Clone)]
 pub struct DashboardStore {
-  inner: Rc<RefCell<DashboardStoreInner>>,
+    inner: Rc<RefCell<DashboardStoreInner>>,
 }
 
 impl DashboardStore {
-  pub fn new(store: DashboardStoreInner) -> Self {
-    Self { inner: Rc::new(RefCell::new(store)) }
-  }
+    pub fn new(store: DashboardStoreInner) -> Self {
+        Self {
+            inner: Rc::new(RefCell::new(store)),
+        }
+    }
 
-  pub fn command(&mut self, command: &DashboardCommand) -> Result<(), Box<dyn Error>> {
-    self.inner.borrow_mut().command(command)
-  }
+    pub fn command(&mut self, command: &DashboardCommand) -> Result<(), Box<dyn Error>> {
+        self.inner.borrow_mut().command(command)
+    }
 
-  pub fn borrow_inner(&self) -> Ref<DashboardStoreInner> {
-    self.inner.borrow()
-  }
+    pub fn borrow_inner(&self) -> Ref<DashboardStoreInner> {
+        self.inner.borrow()
+    }
 
-  pub fn fold(&mut self) -> Result<(), Box<dyn Error>> {
-    self.inner.borrow_mut().fold()
-  }
+    pub fn fold(&mut self) -> Result<(), Box<dyn Error>> {
+        self.inner.borrow_mut().fold()
+    }
 }
 
 pub fn dashboard_store() -> Result<DashboardStore, Box<dyn Error>> {
-  Ok(DashboardStore::new(
-  DashboardStoreInner::new(
-    "data/dashboard/transactions/".into(),
-    KVStore::new(
-      "data/dashboard/snapshots/".into(),
-      "data/dashboard/events/".into(),
-      10,
-    )?
-  )))
+    Ok(DashboardStore::new(DashboardStoreInner::new(
+        "data/dashboard/transactions/".into(),
+        KVStore::new(
+            "data/dashboard/snapshots/".into(),
+            "data/dashboard/events/".into(),
+            10,
+        )?,
+    )))
+}
+
+pub type RegistrationStoreInner =
+    CQRSStore<RegistrationCommand, RegistrationModel, RegistrationCommand>;
+
+#[derive(Clone)]
+pub struct RegistrationStore {
+    inner: Rc<RefCell<RegistrationStoreInner>>,
+}
+
+impl RegistrationStore {
+    pub fn new(store: RegistrationStoreInner) -> Self {
+        Self {
+            inner: Rc::new(RefCell::new(store)),
+        }
+    }
+
+    pub fn command(&mut self, command: &RegistrationCommand) -> Result<(), Box<dyn Error>> {
+        self.inner.borrow_mut().command(command)
+    }
+
+    pub fn borrow_inner(&self) -> Ref<RegistrationStoreInner> {
+        self.inner.borrow()
+    }
+
+    pub fn fold(&mut self) -> Result<(), Box<dyn Error>> {
+        self.inner.borrow_mut().fold()
+    }
+}
+
+pub fn registration_store() -> Result<RegistrationStore, Box<dyn Error>> {
+    Ok(RegistrationStore::new(RegistrationStoreInner::new(
+        "data/registration/transactions/".into(),
+        KVStore::new(
+            "data/registration/snapshots/".into(),
+            "data/registration/events/".into(),
+            10,
+        )?,
+    )))
 }

--- a/backend/tests/executor.rs
+++ b/backend/tests/executor.rs
@@ -1,0 +1,53 @@
+use backend::{AsyncTcpStream, NetExecutor};
+use std::io::Write;
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::channel;
+use std::time::Duration;
+
+#[test]
+fn executor_responsive_multiple_connections() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let executor = NetExecutor::new();
+
+    let mut c1 = TcpStream::connect(addr).unwrap();
+    let mut c2 = TcpStream::connect(addr).unwrap();
+
+    let (s1, _) = listener.accept().unwrap();
+    let (s2, _) = listener.accept().unwrap();
+
+    let mut a1 = AsyncTcpStream::new(s1, executor.clone()).unwrap();
+    let mut a2 = AsyncTcpStream::new(s2, executor.clone()).unwrap();
+
+    let (done_tx, done_rx) = channel();
+    let (l1_tx, l1_rx) = channel();
+    let (l2_tx, l2_rx) = channel();
+
+    executor.clone().spawn(async move {
+        let line = a1.read_line().await.unwrap();
+        l1_tx.send(line).unwrap();
+        std::future::pending::<()>().await;
+    });
+
+    executor.clone().spawn(async move {
+        let line = a2.read_line().await.unwrap();
+        l2_tx.send(line).unwrap();
+        std::future::pending::<()>().await;
+    });
+
+    executor.clone().spawn(async move {
+        done_tx.send(()).unwrap();
+    });
+
+    executor.run_for(Duration::from_millis(50));
+    assert!(done_rx.try_recv().is_ok());
+
+    c1.write_all(b"one\n").unwrap();
+    c2.write_all(b"two\n").unwrap();
+
+    executor.run_for(Duration::from_millis(50));
+
+    assert_eq!(l1_rx.try_recv().unwrap().trim(), "one");
+    assert_eq!(l2_rx.try_recv().unwrap().trim(), "two");
+}

--- a/frontend/src/hooks/mod.rs
+++ b/frontend/src/hooks/mod.rs
@@ -1,5 +1,5 @@
-
 pub mod use_dashboard_api;
+pub mod use_dashboard_login;
 pub mod use_event;
 pub mod use_platform_login;
-pub mod use_dashboard_login;
+pub mod use_register_event;

--- a/frontend/src/hooks/use_register_event.rs
+++ b/frontend/src/hooks/use_register_event.rs
@@ -1,0 +1,36 @@
+use crate::{ClientContext, ToastContext, ToastKind, ToastMessage};
+use dioxus::prelude::*;
+use models::Registration;
+
+pub fn use_register_event(
+    trigger: Signal<Option<(String, String)>>,
+    mut toast: Signal<ToastContext>,
+    client: Signal<ClientContext>,
+) -> Resource<Option<Registration>> {
+    use_resource(move || async move {
+        let Some((event_id, email)) = &*trigger.read() else {
+            return None;
+        };
+        let result = client()
+            .client
+            .post("http://localhost:8000/dashboard/register_event")
+            .header("x-id", event_id.clone())
+            .header("x-email", email.clone())
+            .send()
+            .await;
+        let parsed = match result {
+            Ok(resp) => resp.json::<Registration>().await,
+            Err(e) => Err(e),
+        };
+        match parsed {
+            Ok(reg) => Some(reg),
+            Err(_) => {
+                toast.write().toast = Some(ToastMessage {
+                    message: "Failed to register".to_string(),
+                    kind: ToastKind::Error,
+                });
+                None
+            }
+        }
+    })
+}

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -4,25 +4,27 @@ pub mod hooks;
 pub use hooks::use_dashboard_api::use_dashboard_api;
 pub use hooks::use_event::use_event;
 pub use hooks::use_platform_login::use_platform_login;
+pub use hooks::use_register_event::use_register_event;
+pub use hooks::use_dashboard_login::use_dashboard_login;
 
 pub mod components;
-pub use components::toast::Toast;
 pub use components::notifications::NotificationsDropdown;
-
+pub use components::toast::Toast;
 
 pub mod context;
+pub use context::brand::BrandContext;
+pub use context::client::ClientContext;
+pub use context::toast::Toast as ToastMessage;
 pub use context::toast::ToastContext;
 pub use context::toast::ToastKind;
-pub use context::toast::Toast as ToastMessage;
-pub use context::client::ClientContext;
-pub use context::brand::BrandContext;
 
 pub mod pages;
 pub use pages::homepage::Homepage;
 pub use pages::login::Login;
 pub use pages::signup::Signup;
 pub use pages::get_started::GetStarted;
-pub use pages::get_started::ConfigurePlatform;
+pub use pages::configure_platform::ConfigurePlatform;
+pub use pages::manage_platform::ManagePlatform;
 pub use pages::not_found::PageNotFound;
 pub use pages::dashboard::Dashboard;
 pub use pages::create_event::CreateEvent;
@@ -42,6 +44,8 @@ pub enum Route {
     GetStarted,
     #[route("/configure-platform")]
     ConfigurePlatform,
+    #[route("/manage-platform")]
+    ManagePlatform,
     #[route("/dashboard")]
     Dashboard,
     #[route("/create-event")]

--- a/frontend/src/pages/configure_platform.rs
+++ b/frontend/src/pages/configure_platform.rs
@@ -1,0 +1,72 @@
+use dioxus::prelude::*;
+use crate::{BrandContext, ClientContext};
+use models::Platform;
+
+#[component]
+pub fn ConfigurePlatform() -> Element {
+    let brand = use_context::<Signal<BrandContext>>();
+    let client = use_context::<Signal<ClientContext>>();
+    let BrandContext { name: _, logo: _, primary_color: _, secondary_color } = brand.read().clone();
+
+    let mut community_name = use_signal(|| String::new());
+    let mut community_description = use_signal(|| String::new());
+    let mut platform_url = use_signal(|| String::new());
+    let mut submit = use_signal(|| false);
+
+    use_future(move || async move {
+        if !submit() { return; }
+        let platform = Platform {
+            tenant_id: "bucket-golf".into(),
+            community_name: community_name(),
+            community_description: community_description(),
+            platform_url: platform_url(),
+        };
+        let _ = client().client
+            .post("http://localhost:8000/platform/create")
+            .json(&platform)
+            .send()
+            .await;
+    });
+
+    rsx!(
+        div { style: "min-height: 100vh; padding: 3rem 1rem; background-color: #f9fafb; font-family: sans-serif;",
+            div { style: "max-width: 40rem; margin: 0 auto;",
+                h1 { style: "font-size: 2rem; font-weight: bold; color: #111827; text-align: center; margin-bottom: 2rem;",
+                    "Configure Your Platform"
+                }
+                p { style: "font-size: 1rem; color: #4b5563; margin-bottom: 1.5rem;",
+                    "Set your branding, community rules, and permissions (you can change this later)."
+                }
+                form { style: "display: flex; flex-direction: column; gap: 1rem;",
+                    input {
+                        r#type: "text",
+                        placeholder: "Community Name",
+                        oninput: move |e| community_name.set(e.value()),
+                        value: community_name.clone(),
+                        style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
+                    }
+                    textarea {
+                        placeholder: "Community Description",
+                        oninput: move |e| community_description.set(e.value()),
+                        value: community_description.clone(),
+                        style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; height: 100px;",
+                    }
+                    input {
+                        r#type: "url",
+                        placeholder: "Platform URL",
+                        oninput: move |e| platform_url.set(e.value()),
+                        value: platform_url.clone(),
+                        style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
+                    }
+                    p { style: "font-size: 0.875rem; color: #6b7280; margin-top: -0.75rem; margin-bottom: 0.5rem;",
+                        "DNS update instructions will be sent to your account's email"
+                    }
+                    button { style: "background-color: {secondary_color}; color: white; font-weight: 600; padding: 0.75rem 1.5rem; border-radius: 0.5rem; border: none; cursor: pointer;",
+                        onclick: move |_| submit.set(true),
+                        "Save & Continue"
+                    }
+                }
+            }
+        }
+    )
+}

--- a/frontend/src/pages/create_event.rs
+++ b/frontend/src/pages/create_event.rs
@@ -65,6 +65,7 @@ pub fn CreateEvent() -> Element {
                             image: String::new(),
                             banner: None,
                             upsell: None,
+                            active: false,
                         }));
                     },
                     div {

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -202,10 +202,39 @@ pub fn EventCard(event: Event) -> Element {
                 transition: background 0.2s;
                 align-self: start;
                 box-shadow: 0 1px 4px rgba(234,62,78,0.07);
-                border: none;
-                cursor: pointer;
-              ",
+              border: none;
+              cursor: pointer;
+            ",
               "View Event"
+            }
+            if event.active {
+              button {
+                style: "
+                  margin-top: 0.5rem;
+                  background-color: #fee2e2;
+                  color: #b91c1c;
+                  border: none;
+                  padding: 0.4rem 0.8rem;
+                  border-radius: 9999px;
+                  font-size: 0.9rem;
+                  cursor: pointer;
+                ",
+                "End"
+              }
+            } else {
+              button {
+                style: "
+                  margin-top: 0.5rem;
+                  background-color: #dcfce7;
+                  color: #166534;
+                  border: none;
+                  padding: 0.4rem 0.8rem;
+                  border-radius: 9999px;
+                  font-size: 0.9rem;
+                  cursor: pointer;
+                ",
+                "Start"
+              }
             }
           }
         }
@@ -357,9 +386,23 @@ pub fn ActiveEvents(events: Vec<Event>) -> Element {
                 padding: 0.5rem 1rem;
                 border-radius: 9999px;
                 text-decoration: none;
+                margin-right: 0.5rem;
                 transition: background-color 0.2s ease;
               ",
                 "View Details"
+              }
+              button {
+                style: "
+                font-size: 0.875rem;
+                font-weight: 500;
+                color: #dc2626;
+                background-color: #fee2e2;
+                padding: 0.5rem 1rem;
+                border-radius: 9999px;
+                border: none;
+                cursor: pointer;
+              ",
+                "End Event"
               }
             }
           }

--- a/frontend/src/pages/event_register.rs
+++ b/frontend/src/pages/event_register.rs
@@ -1,23 +1,24 @@
+use crate::{use_event, use_register_event, ClientContext, ToastContext};
 use dioxus::prelude::*;
-use crate::{use_event, ToastContext, ClientContext};
 const BUCKET_GOLF_SVG: Asset = asset!("/assets/bucket-golf.png");
 
 #[component]
 pub fn RegisterEvent(id: String) -> Element {
-    let data = use_event(id,
-      use_context::<Signal<ToastContext>>(),
-      use_context::<Signal<ClientContext>>(),
+    let data = use_event(
+        id,
+        use_context::<Signal<ToastContext>>(),
+        use_context::<Signal<ClientContext>>(),
     );
 
     match data.read_unchecked().as_ref() {
         Some(Some(event)) => rsx!(RegisterEventInner {
-          id: event.id.clone(),
-          name: event.name.clone(),
-          location: event.location.clone(),
-          date: event.date.clone(),
-          image: event.image.clone(),
-          banner: event.banner.clone(),
-          upsell: event.upsell.clone()
+            id: event.id.clone(),
+            name: event.name.clone(),
+            location: event.location.clone(),
+            date: event.date.clone(),
+            image: event.image.clone(),
+            banner: event.banner.clone(),
+            upsell: event.upsell.clone()
         }),
         _ => rsx!(),
     }
@@ -25,17 +26,25 @@ pub fn RegisterEvent(id: String) -> Element {
 
 #[component]
 pub fn RegisterEventInner(
-  id: String,
-  name: String,
-  location: String,
-  date: String,
-  image: String,
-  banner: Option<String>,
-  upsell: Option<String>,
+    id: String,
+    name: String,
+    location: String,
+    date: String,
+    image: String,
+    banner: Option<String>,
+    upsell: Option<String>,
 ) -> Element {
-  rsx!(
-    div {
-      style: "
+    let mut email = use_signal(|| String::new());
+    let mut trigger = use_signal(|| None);
+    let _reg = use_register_event(
+        trigger,
+        use_context::<Signal<ToastContext>>(),
+        use_context::<Signal<ClientContext>>(),
+    );
+
+    rsx!(
+      div {
+        style: "
         min-height: 100vh;
         background-color: #f9fafb;
         font-family: sans-serif;
@@ -43,8 +52,8 @@ pub fn RegisterEventInner(
         display: flex;
         justify-content: center;
       ",
-      div {
-        style: "
+        div {
+          style: "
           max-width: 48rem;
           width: 100%;
           background: white;
@@ -53,94 +62,98 @@ pub fn RegisterEventInner(
           box-shadow: 0 4px 12px rgba(0,0,0,0.05);
         ",
 
-        // Banner
-        if let Some(b) = banner.clone() {
-          div {
-            style: "background-color: #fde68a; color: #78350f; font-weight: bold; text-align: center; padding: 0.5rem; margin-bottom: 1rem;",
-            "{b}"
+          // Banner
+          if let Some(b) = banner.clone() {
+            div {
+              style: "background-color: #fde68a; color: #78350f; font-weight: bold; text-align: center; padding: 0.5rem; margin-bottom: 1rem;",
+              "{b}"
+            }
           }
-        }
 
-        // Event header
-        h1 {
-          style: "font-size: 2rem; font-weight: bold; color: #111827; margin-bottom: 0.5rem;",
-          "Register for {name}"
-        }
+          // Event header
+          h1 {
+            style: "font-size: 2rem; font-weight: bold; color: #111827; margin-bottom: 0.5rem;",
+            "Register for {name}"
+          }
 
-        p {
-          style: "color: #6b7280; margin-bottom: 1.5rem;",
-          "{date} · {location}"
-        }
-
-        img {
-          src: BUCKET_GOLF_SVG,
-          alt: "Event image",
-          style: "width: 100%; max-height: 200px; object-fit: cover; border-radius: 0.5rem; margin-bottom: 2rem;"
-        }
-
-        if let Some(u) = upsell.clone() {
           p {
-            style: "color: #dc2626; font-weight: 500; font-size: 0.95rem; margin-bottom: 1.5rem;",
-            "{u}"
-          }
-        }
-
-        // Pricing breakdown
-        div {
-          style: "margin-bottom: 2rem;",
-          h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Order Summary" }
-          ul {
-            style: "font-size: 0.95rem; color: #374151; margin-bottom: 1rem;",
-            li { "🏷️ Registration Fee: $20.00" }
-            li { "⚙️ Service Fee: $2.00" }
-            li { "📊 Taxes: $1.80" }
-            li { "💖 Optional Donation: $0.00" }
-          }
-          p { style: "font-weight: bold; font-size: 1.125rem; margin-top: 1rem;", "Total: $23.80" }
-        }
-
-        // Auth options
-        div {
-          style: "margin-bottom: 2rem;",
-          h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Your Account" }
-
-          input {
-            r#type: "email",
-            placeholder: "Email address",
-            style: base_input()
+            style: "color: #6b7280; margin-bottom: 1.5rem;",
+            "{date} · {location}"
           }
 
-          input {
-            r#type: "password",
-            placeholder: "Create a password or enter existing",
-            style: base_input()
+          img {
+            src: BUCKET_GOLF_SVG,
+            alt: "Event image",
+            style: "width: 100%; max-height: 200px; object-fit: cover; border-radius: 0.5rem; margin-bottom: 2rem;"
           }
 
-          a {
-            href: "#",
-            style: "font-size: 0.875rem; color: #4f46e5; text-decoration: underline;",
-            "Already have an account? Log in"
+          if let Some(u) = upsell.clone() {
+            p {
+              style: "color: #dc2626; font-weight: 500; font-size: 0.95rem; margin-bottom: 1.5rem;",
+              "{u}"
+            }
           }
-        }
 
-        // Billing address
-        div {
-          style: "margin-bottom: 2rem;",
-          h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Billing Address" }
-
-          input { placeholder: "Full Name", style: base_input() }
-          input { placeholder: "Street Address", style: base_input() }
-          input { placeholder: "City", style: base_input() }
-          input { placeholder: "State", style: base_input() }
-          input { placeholder: "Zip Code", style: base_input() }
-        }
-
-        // Payment section placeholder
-        div {
-          style: "margin-bottom: 2rem;",
-          h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Payment" }
+          // Pricing breakdown
           div {
-            style: "
+            style: "margin-bottom: 2rem;",
+            h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Order Summary" }
+            ul {
+              style: "font-size: 0.95rem; color: #374151; margin-bottom: 1rem;",
+              li { "🏷️ Registration Fee: $20.00" }
+              li { "⚙️ Service Fee: $2.00" }
+              li { "📊 Taxes: $1.80" }
+              li { "💖 Optional Donation: $0.00" }
+            }
+            p { style: "font-weight: bold; font-size: 1.125rem; margin-top: 1rem;", "Total: $23.80" }
+          }
+
+          // Auth options
+          div {
+            style: "margin-bottom: 2rem;",
+            h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Your Account" }
+
+            input {
+              r#type: "email",
+              placeholder: "Email address",
+              oninput: move |e| {
+                email.set(e.value());
+              },
+              value: email,
+              style: base_input()
+            }
+
+            input {
+              r#type: "password",
+              placeholder: "Create a password or enter existing",
+              style: base_input()
+            }
+
+            a {
+              href: "#",
+              style: "font-size: 0.875rem; color: #4f46e5; text-decoration: underline;",
+              "Already have an account? Log in"
+            }
+          }
+
+          // Billing address
+          div {
+            style: "margin-bottom: 2rem;",
+            h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Billing Address" }
+
+            input { placeholder: "Full Name", style: base_input() }
+            input { placeholder: "Street Address", style: base_input() }
+            input { placeholder: "City", style: base_input() }
+            input { placeholder: "State", style: base_input() }
+            input { placeholder: "Zip Code", style: base_input() }
+          }
+
+          // Payment section placeholder
+          div {
+            style: "margin-bottom: 2rem;",
+            h2 { style: "font-size: 1.125rem; font-weight: 600; margin-bottom: 1rem;", "Payment" }
+            div {
+              style: "
               padding: 1.5rem;
               border: 2px dashed #d1d5db;
               border-radius: 0.5rem;
@@ -148,12 +161,12 @@ pub fn RegisterEventInner(
               color: #9ca3af;
               font-size: 0.95rem;
             ",
-            "💳 Payment integration coming soon..."
+              "💳 Payment integration coming soon..."
+            }
           }
-        }
 
-        button {
-          style: "
+          button {
+            style: "
             width: 100%;
             background-color: #4f46e5;
             color: white;
@@ -164,15 +177,18 @@ pub fn RegisterEventInner(
             border-radius: 0.5rem;
             cursor: pointer;
           ",
-          "Complete Registration"
+            onclick: move |_| {
+              trigger.set(Some((id.clone(), email())));
+            },
+            "Complete Registration"
+          }
         }
       }
-    }
-  )
+    )
 }
 
 fn base_input() -> &'static str {
-  "
+    "
     width: 100%;
     padding: 0.75rem;
     margin-bottom: 0.75rem;

--- a/frontend/src/pages/get_started.rs
+++ b/frontend/src/pages/get_started.rs
@@ -34,45 +34,6 @@ pub fn GetStarted() -> Element {
     )
 }
 
-#[component]
-pub fn ConfigurePlatform() -> Element {
-  let brand = use_context::<Signal<BrandContext>>();
-  let BrandContext {name: _, logo: _, primary_color: _, secondary_color} = brand.read().clone();
-    rsx!(
-      div { style: "min-height: 100vh; padding: 3rem 1rem; background-color: #f9fafb; font-family: sans-serif;",
-        div { style: "max-width: 40rem; margin: 0 auto;",
-          h1 { style: "font-size: 2rem; font-weight: bold; color: #111827; text-align: center; margin-bottom: 2rem;",
-            "Configure Your Platform"
-          }
-          p { style: "font-size: 1rem; color: #4b5563; margin-bottom: 1.5rem;",
-            "Set your branding, community rules, and permissions (you can change this later)."
-          }
-          form { style: "display: flex; flex-direction: column; gap: 1rem;",
-            input {
-              r#type: "text",
-              placeholder: "Community Name",
-              style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
-            }
-            textarea {
-              placeholder: "Community Description",
-              style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; height: 100px;",
-            }
-            input {
-              r#type: "url",
-              placeholder: "Platform URL",
-              style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
-            }
-            p { style: "font-size: 0.875rem; color: #6b7280; margin-top: -0.75rem; margin-bottom: 0.5rem;",
-              "DNS update instructions will be sent to your account's email"
-            }
-            button { style: "background-color: {secondary_color}; color: white; font-weight: 600; padding: 0.75rem 1.5rem; border-radius: 0.5rem; border: none; cursor: pointer;",
-              "Save & Continue"
-            }
-          }
-        }
-      }
-    )
-}
 
 #[component]
 pub fn InsightsDashboard() -> Element {

--- a/frontend/src/pages/login.rs
+++ b/frontend/src/pages/login.rs
@@ -1,5 +1,5 @@
 use dioxus::prelude::*;
-use crate::{Route, BrandContext, use_platform_login, ClientContext, ToastContext};
+use crate::{Route, BrandContext, use_dashboard_login, ClientContext, ToastContext};
 use models::{LoginAttempt};
 
 #[component]
@@ -11,7 +11,7 @@ pub fn Login() -> Element {
   let mut login_attempt = use_signal(|| None);
 
 
-  let user = use_platform_login(
+  let user = use_dashboard_login(
     login_attempt,
     use_context::<Signal<ToastContext>>(),
     use_context::<Signal<ClientContext>>(),

--- a/frontend/src/pages/manage_platform.rs
+++ b/frontend/src/pages/manage_platform.rs
@@ -1,0 +1,67 @@
+use dioxus::prelude::*;
+use crate::{BrandContext, ClientContext};
+use models::PlatformPatch;
+
+#[component]
+pub fn ManagePlatform() -> Element {
+    let brand = use_context::<Signal<BrandContext>>();
+    let client = use_context::<Signal<ClientContext>>();
+    let BrandContext { name: _, logo: _, primary_color: _, secondary_color } = brand.read().clone();
+
+    let mut community_name = use_signal(|| String::new());
+    let mut community_description = use_signal(|| String::new());
+    let mut platform_url = use_signal(|| String::new());
+    let mut submit = use_signal(|| false);
+
+    use_future(move || async move {
+        if !submit() { return; }
+        let patch = PlatformPatch {
+            tenant_id: "bucket-golf".into(),
+            community_name: Some(community_name()),
+            community_description: Some(community_description()),
+            platform_url: Some(platform_url()),
+        };
+        let _ = client().client
+            .post("http://localhost:8000/platform/update")
+            .json(&patch)
+            .send()
+            .await;
+    });
+
+    rsx!(
+        div { style: "min-height: 100vh; padding: 3rem 1rem; background-color: #f9fafb; font-family: sans-serif;",
+            div { style: "max-width: 40rem; margin: 0 auto;",
+                h1 { style: "font-size: 2rem; font-weight: bold; color: #111827; text-align: center; margin-bottom: 2rem;",
+                    "Manage Platform"
+                }
+                form { style: "display: flex; flex-direction: column; gap: 1rem;",
+                    input {
+                        r#type: "text",
+                        placeholder: "Community Name",
+                        oninput: move |e| community_name.set(e.value()),
+                        value: community_name.clone(),
+                        style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
+                    }
+                    textarea {
+                        placeholder: "Community Description",
+                        oninput: move |e| community_description.set(e.value()),
+                        value: community_description.clone(),
+                        style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; height: 100px;",
+                    }
+                    input {
+                        r#type: "url",
+                        placeholder: "Platform URL",
+                        oninput: move |e| platform_url.set(e.value()),
+                        value: platform_url.clone(),
+                        style: "padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
+                    }
+                    button { style: "background-color: {secondary_color}; color: white; font-weight: 600; padding: 0.75rem 1.5rem; border-radius: 0.5rem; border: none; cursor: pointer;",
+                        onclick: move |_| submit.set(true),
+                        "Update Platform"
+                    }
+                }
+            }
+        }
+    )
+}
+

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -2,6 +2,8 @@
 pub mod homepage;
 pub mod login;
 pub mod signup;
+pub mod configure_platform;
+pub mod manage_platform;
 pub mod get_started;
 pub mod not_found;
 pub mod dashboard;

--- a/frontend/src/pages/signup.rs
+++ b/frontend/src/pages/signup.rs
@@ -1,10 +1,26 @@
 use dioxus::prelude::*;
-use crate::{Route, BrandContext};
+use crate::{Route, BrandContext, ClientContext};
+use models::PlatformUser;
 
 #[component]
 pub fn Signup() -> Element {
   let brand = use_context::<Signal<BrandContext>>();
+  let client = use_context::<Signal<ClientContext>>();
   let BrandContext {name: _, logo: _, primary_color: _, secondary_color} = brand.read().clone();
+  let mut email = use_signal(|| String::new());
+  let mut password = use_signal(|| String::new());
+  let mut confirm = use_signal(|| String::new());
+  let mut submit = use_signal(|| false);
+
+  use_future(move || async move {
+    if !submit() { return; }
+    let user = PlatformUser { email: email(), password: password() };
+    let _ = client().client
+      .post("http://localhost:8000/platform/user")
+      .json(&user)
+      .send()
+      .await;
+  });
   rsx!(
     div { style: "min-height: 100vh; display: flex; align-items: center; justify-content: center; background-color: #f9fafb; font-family: sans-serif;",
       div { style: "width: 100%; max-width: 24rem; background: white; padding: 2rem; border-radius: 0.5rem; box-shadow: 0 4px 6px rgba(0,0,0,0.1);",
@@ -19,6 +35,8 @@ pub fn Signup() -> Element {
             input {
               r#type: "email",
               placeholder: "you@example.com",
+              oninput: move |e| email.set(e.value()),
+              value: email.clone(),
               style: "width: 100%; padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
             }
           }
@@ -29,6 +47,8 @@ pub fn Signup() -> Element {
             input {
               r#type: "password",
               placeholder: "••••••••",
+              oninput: move |e| password.set(e.value()),
+              value: password.clone(),
               style: "width: 100%; padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
             }
           }
@@ -39,12 +59,15 @@ pub fn Signup() -> Element {
             input {
               r#type: "password",
               placeholder: "••••••••",
+              oninput: move |e| confirm.set(e.value()),
+              value: confirm.clone(),
               style: "width: 100%; padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
             }
           }
           Link { to: Route::ConfigurePlatform {},
             button {
               r#type: "submit",
+              onclick: move |_| submit.set(true),
               style: "margin-top: 1rem; background-color: {secondary_color}; color: white; font-weight: 600; padding: 0.75rem; border: none; border-radius: 0.5rem; cursor: pointer;",
               "Sign Up"
             }

--- a/models/src/dashboard/event.rs
+++ b/models/src/dashboard/event.rs
@@ -16,6 +16,7 @@ pub struct Event {
   pub image: String,
   pub banner: Option<String>,
   pub upsell: Option<String>,
+  pub active: bool,
 }
 
 #[derive(Archive, RkyvDeserialize, RkyvSerialize, SarSerialize, SarDeserialize, Debug, Clone, Default, PartialEq)]
@@ -27,6 +28,7 @@ pub struct EventPatch {
   pub image: Option<String>,
   pub banner: Option<Option<String>>,
   pub upsell: Option<Option<String>>,
+  pub active: Option<bool>,
 }
 
 impl Patch<Event> for EventPatch {
@@ -51,6 +53,9 @@ impl Patch<Event> for EventPatch {
     }
     if let Some(upsell) = self.upsell {
       target.upsell = upsell;
+    }
+    if let Some(active) = self.active {
+      target.active = active;
     }
   }
 }

--- a/models/src/dashboard/mod.rs
+++ b/models/src/dashboard/mod.rs
@@ -1,4 +1,4 @@
-
 pub mod event;
+pub mod registration;
 pub mod store;
 pub mod user;

--- a/models/src/dashboard/registration.rs
+++ b/models/src/dashboard/registration.rs
@@ -1,0 +1,44 @@
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+use serde::{Deserialize as SarDeserialize, Serialize as SarSerialize};
+
+use crate::Patch;
+
+#[derive(
+    Archive,
+    RkyvDeserialize,
+    RkyvSerialize,
+    SarSerialize,
+    SarDeserialize,
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+)]
+pub struct Registration {
+    pub id: String,
+    pub event_id: String,
+    pub email: String,
+}
+
+#[derive(
+    Archive,
+    RkyvDeserialize,
+    RkyvSerialize,
+    SarSerialize,
+    SarDeserialize,
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+)]
+pub struct RegistrationPatch {
+    pub email: Option<String>,
+}
+
+impl Patch<Registration> for RegistrationPatch {
+    fn apply_to(self, target: &mut Registration) {
+        if let Some(email) = self.email {
+            target.email = email;
+        }
+    }
+}

--- a/models/src/dashboard/user.rs
+++ b/models/src/dashboard/user.rs
@@ -50,6 +50,17 @@ impl PartialEq<LoginAttempt> for DashboardUser {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+impl PartialEq<crate::platform::user::LoginAttempt> for DashboardUser {
+  fn eq(&self, attempt: &crate::platform::user::LoginAttempt) -> bool {
+    if self.email != attempt.email {
+      return false;
+    }
+
+    verify_password(&attempt.password, &self.password)
+  }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 impl Patch<DashboardUser> for DashboardUserPatch {
   fn apply_to(self, target: &mut DashboardUser) -> () {
     if let Some(password) = self.password {

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -1,14 +1,14 @@
-
 mod platform;
-pub use platform::user::{PlatformUser, PlatformUserPatch, LoginAttempt};
 pub use platform::platform::{Platform, PlatformPatch};
+pub use platform::user::{LoginAttempt, PlatformUser, PlatformUserPatch};
 
 mod dashboard;
+pub use dashboard::event::{ArchivedEvent, Event, EventPatch};
+pub use dashboard::registration::{Registration, RegistrationPatch};
 pub use dashboard::store::{DashboardData, DashboardView};
-pub use dashboard::event::{Event, EventPatch, ArchivedEvent};
 pub use dashboard::user::{DashboardUser, DashboardUserPatch};
 
 mod utils;
-pub use utils::{EntityId, Patch};
 #[cfg(not(target_arch = "wasm32"))]
 pub use utils::{hash_password, verify_password};
+pub use utils::{EntityId, Patch};


### PR DESCRIPTION
## Summary
- expose `create_event_route` module
- add `/create-event` handling in the backend server
- implement `create_event_route` for DashboardStore persistence
- hook create event form submission to call the backend

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_687ecdaee278832bab14813d01908101