### PR TITLE
Improve login and registration routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "rkyv_derive",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -15,3 +15,6 @@ http = "1.0"
 log4rs = "1.3.0"
 log = "0.4"
 polling = "3.7.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/backend/src/api/login.rs
+++ b/backend/src/api/login.rs
@@ -1,40 +1,52 @@
 use http::Request;
 use http::Response;
 use http::StatusCode;
+use log::{info, warn};
 use std::error::Error;
-use crate::not_found_route;
 
-use crate::{PlatformStore, PlatformModel};
+use crate::{PlatformModel, PlatformStore};
 use models::LoginAttempt;
 
+/// Authenticate a platform user.
+///
+/// Returns `UNAUTHORIZED` if credentials are incorrect or
+/// `BAD_REQUEST` when a required field is empty.
 pub fn login_route(
-  _req: &Request<()>,
-  platform_store: PlatformStore,
-  email: String,
-  password: String,
+    _req: &Request<()>,
+    platform_store: PlatformStore,
+    email: String,
+    password: String,
 ) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
-  let user = platform_store.borrow_inner()
-    .query_owned(format!("user-{}", email.clone()))?;
+    info!("login attempt for {email}");
 
-  let login_attempt = LoginAttempt {
-    email,
-    password,
-  };
-
-  match user {
-    Some(PlatformModel::User(user)) if user == login_attempt => {
-      let json = serde_json::to_vec(&user)?;
-
-      Ok(Response::builder()
-        .status(StatusCode::OK)
-        .header("Content-Type", "application/json")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Access-Control-Allow-Methods", "*")
-        .header("Access-Control-Allow-Headers", "*")
-        .body(json)?)
-    },
-    _ => {
-      not_found_route()
+    if email.trim().is_empty() || password.trim().is_empty() {
+        warn!("login request missing credentials");
+        return Ok(Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(b"{}".to_vec())?);
     }
-  }
+
+    let user = platform_store
+        .borrow_inner()
+        .query_owned(format!("user-{email}"))?;
+
+    let login_attempt = LoginAttempt { email, password };
+
+    match user {
+        Some(PlatformModel::User(user)) if user == login_attempt => {
+            let json = serde_json::to_vec(&user)?;
+
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
+                .body(json)?)
+        }
+        _ => Ok(Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header("Content-Type", "application/json")
+            .body(b"{}".to_vec())?),
+    }
 }

--- a/backend/src/api/register_event_route.rs
+++ b/backend/src/api/register_event_route.rs
@@ -1,24 +1,42 @@
 use http::{Request, Response, StatusCode};
+use log::{error, info, warn};
 use std::error::Error;
 
 use crate::{RegistrationCommand, RegistrationStore};
 use models::Registration;
 
+/// Register a user for a given event. Returns the registration record as JSON.
+/// A `BAD_REQUEST` response is returned when parameters are empty.
 pub fn register_event_route(
     _req: &Request<()>,
     mut store: RegistrationStore,
     event_id: String,
     email: String,
 ) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+    info!("register `{email}` for event `{event_id}`");
+
+    if event_id.trim().is_empty() || email.trim().is_empty() {
+        warn!("invalid registration parameters");
+        return Ok(Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .header("Content-Type", "application/json")
+            .body(b"{}".to_vec())?);
+    }
+
     let registration = Registration {
         id: format!("{}-{}", event_id, email),
         event_id,
         email,
     };
 
-    store.command(&RegistrationCommand::CreateRegistration(
+    if let Err(e) = store.command(&RegistrationCommand::CreateRegistration(
         registration.clone(),
-    ))?;
+    )) {
+        error!("failed to create registration: {e}");
+        return Ok(Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(b"{}".to_vec())?);
+    }
 
     let json = serde_json::to_vec(&registration)?;
 

--- a/backend/tests/routes.rs
+++ b/backend/tests/routes.rs
@@ -1,0 +1,91 @@
+use backend::store::dashboard::RegistrationStoreInner;
+use backend::store::platform::PlatformStoreInner;
+use backend::{login_route, register_event_route};
+use backend::{KVStore, PlatformCommand, PlatformStore, RegistrationModel, RegistrationStore};
+use http::{Request, StatusCode};
+use models::PlatformUser;
+use tempfile::tempdir;
+
+fn temp_registration_store() -> RegistrationStore {
+    let dir = tempdir().unwrap().into_path();
+    let inner = RegistrationStoreInner::new(
+        dir.join("txn"),
+        KVStore::new(dir.join("snap"), dir.join("event"), 1).unwrap(),
+    );
+    RegistrationStore::new(inner)
+}
+
+fn temp_platform_store() -> PlatformStore {
+    let dir = tempdir().unwrap().into_path();
+    let inner = PlatformStoreInner::new(
+        dir.join("txn"),
+        KVStore::new(dir.join("snap"), dir.join("event"), 1).unwrap(),
+    );
+    PlatformStore::new(inner)
+}
+
+#[test]
+fn register_event_success() {
+    let mut store = temp_registration_store();
+    let response = register_event_route(
+        &Request::default(),
+        store.clone(),
+        "e1".into(),
+        "user@example.com".into(),
+    )
+    .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    store.fold().unwrap();
+    let reg = store
+        .borrow_inner()
+        .query_owned("e1-user@example.com".into())
+        .unwrap();
+    assert!(matches!(reg, Some(RegistrationModel::Registration(_))));
+}
+
+#[test]
+fn register_event_invalid() {
+    let store = temp_registration_store();
+    let response = register_event_route(&Request::default(), store, "".into(), "".into()).unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn login_route_success() {
+    let mut store = temp_platform_store();
+    store
+        .command(&PlatformCommand::CreateUser(PlatformUser::new(
+            "u@example.com".into(),
+            "pw".into(),
+        )))
+        .unwrap();
+    store.fold().unwrap();
+    let res = login_route(
+        &Request::default(),
+        store,
+        "u@example.com".into(),
+        "pw".into(),
+    )
+    .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[test]
+fn login_route_fail() {
+    let mut store = temp_platform_store();
+    store
+        .command(&PlatformCommand::CreateUser(PlatformUser::new(
+            "u@example.com".into(),
+            "pw".into(),
+        )))
+        .unwrap();
+    store.fold().unwrap();
+    let res = login_route(
+        &Request::default(),
+        store,
+        "u@example.com".into(),
+        "wrong".into(),
+    )
+    .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}


### PR DESCRIPTION
## Summary
- add detailed logging and input validation in login and registration routes
- enable `tempfile` for backend tests
- add regression tests for login and register API functions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688230df420c832bbec4895735e52610