### PR TITLE
Enhance login logging and tests

### DIFF
--- a/backend/tests/routes.rs
+++ b/backend/tests/routes.rs
@@ -94,8 +94,15 @@ fn login_route_fail() {
 }
 
 #[test]
-fn platform_create_route_success() {
+fn login_route_missing_credentials() {
     let store = temp_platform_store();
+    let res = login_route(&Request::default(), store, "".into(), "".into()).unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn platform_create_route_success() {
+    let mut store = temp_platform_store();
     let platform = Platform {
         tenant_id: "t1".into(),
         community_name: "Test".into(),


### PR DESCRIPTION
## Summary
- add logging for platform user lookup failures
- log successful and invalid login attempts
- test login route for missing credential handling
- make platform creation test use mutable store

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6882a86b7ec4832baa6b3ead32f4d221