### PR TITLE
Add dashboard login route

### DIFF
--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -21,6 +21,7 @@ pub use context::toast::ToastKind;
 pub mod pages;
 pub use pages::homepage::Homepage;
 pub use pages::login::Login;
+pub use pages::dashboard_login::DashboardLogin;
 pub use pages::signup::Signup;
 pub use pages::get_started::GetStarted;
 pub use pages::configure_platform::ConfigurePlatform;
@@ -38,6 +39,8 @@ pub enum Route {
     Homepage,
     #[route("/login")]
     Login,
+    #[route("/dashboard-login")]
+    DashboardLogin,
     #[route("/signup")]
     Signup,
     #[route("/get-started")]

--- a/frontend/src/pages/dashboard_login.rs
+++ b/frontend/src/pages/dashboard_login.rs
@@ -1,0 +1,84 @@
+use dioxus::prelude::*;
+use crate::{Route, BrandContext, use_dashboard_login, ClientContext, ToastContext};
+use models::{LoginAttempt};
+
+#[component]
+pub fn DashboardLogin() -> Element {
+  let brand = use_context::<Signal<BrandContext>>();
+  let BrandContext {name, logo: _, primary_color: _, secondary_color} = brand.read().clone();
+  let mut email = use_signal(|| String::new());
+  let mut password = use_signal(|| String::new());
+  let mut login_attempt = use_signal(|| None);
+
+
+  let user = use_dashboard_login(
+    login_attempt,
+    use_context::<Signal<ToastContext>>(),
+    use_context::<Signal<ClientContext>>(),
+  );
+  println!("User: {:?}", user.read());
+
+  rsx!(
+    div { style: "min-height: 100vh; display: flex; align-items: center; justify-content: center; background-color: #f9fafb; font-family: sans-serif;",
+      div { style: "width: 100%; max-width: 24rem; background: white; padding: 2rem; border-radius: 0.5rem; box-shadow: 0 4px 6px rgba(0,0,0,0.1);",
+        h2 { style: "text-align: center; font-size: 1.5rem; font-weight: bold; margin-bottom: 1rem; color: #111827;",
+          "Sign in to {name}"
+        }
+        div { style: "display: flex; flex-direction: column; gap: 1rem;",
+          div {
+            label { style: "display: block; margin-bottom: 0.25rem; font-weight: 500;",
+              "Email"
+            }
+            input {
+              r#type: "email",
+              placeholder: "you@example.com",
+              oninput: move |e| {
+                  email.set(e.value());
+              },
+              value: email,
+              style: "width: 100%; padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
+            }
+          }
+          div {
+            label { style: "display: block; margin-bottom: 0.25rem; font-weight: 500;",
+              "Password"
+            }
+            input {
+              r#type: "password",
+              placeholder: "••••••••",
+              oninput: move |e| {
+                  password.set(e.value());
+              },
+              value: password,
+              style: "width: 100%; padding: 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem;",
+            }
+          }
+          button {
+            r#type: "submit",
+            onclick: move |_| {
+                login_attempt
+                    .set(
+                        Some(LoginAttempt {
+                            email: email(),
+                            password: password(),
+                        }),
+                    );
+            },
+            style: "margin-top: 1rem; background-color: {secondary_color}; color: white; font-weight: 600; padding: 0.75rem; border: none; border-radius: 0.5rem; cursor: pointer;",
+            "Sign In"
+          }
+        }
+        Link { to: Route::GetStarted {},
+          p { style: "margin-top: 1rem; text-align: center; font-size: 0.875rem; color: #6b7280;",
+            "Don't have an account? "
+            a {
+              href: "#",
+              style: "color: {secondary_color}; text-decoration: none; font-weight: 500;",
+              "Sign up"
+            }
+          }
+        }
+      }
+    }
+  )
+}

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -1,6 +1,7 @@
 
 pub mod homepage;
 pub mod login;
+pub mod dashboard_login;
 pub mod signup;
 pub mod configure_platform;
 pub mod manage_platform;


### PR DESCRIPTION
## Summary
- add a new DashboardLogin page that reuses `use_dashboard_login`
- wire the new page and route into lib.rs and pages module

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_688a11e59804832b9cd81b7f929442de