### PR TITLE
Switch login page to platform hook

### DIFF
--- a/frontend/src/pages/login.rs
+++ b/frontend/src/pages/login.rs
@@ -1,5 +1,5 @@
 use dioxus::prelude::*;
-use crate::{Route, BrandContext, use_dashboard_login, ClientContext, ToastContext};
+use crate::{Route, BrandContext, use_platform_login, ClientContext, ToastContext};
 use models::{LoginAttempt};
 
 #[component]
@@ -11,7 +11,7 @@ pub fn Login() -> Element {
   let mut login_attempt = use_signal(|| None);
 
 
-  let user = use_dashboard_login(
+  let user = use_platform_login(
     login_attempt,
     use_context::<Signal<ToastContext>>(),
     use_context::<Signal<ClientContext>>(),


### PR DESCRIPTION
## Summary
- call `use_platform_login` instead of `use_dashboard_login`
- update the import accordingly

## Testing
- `mise exec -- cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688a581304dc832bb1893707d32525ae