### PR TITLE
Add JWT issuance on login

### DIFF
--- a/backend/src/api/dashboard_login.rs
+++ b/backend/src/api/dashboard_login.rs
@@ -4,7 +4,7 @@ use http::StatusCode;
 use std::error::Error;
 
 use crate::not_found_route;
-use crate::{DashboardModel, DashboardStore};
+use crate::{generate as jwt_generate, DashboardModel, DashboardStore};
 use log::{info, warn};
 use models::LoginAttempt;
 
@@ -26,9 +26,11 @@ pub fn dashboard_login_route(
     let login_attempt = LoginAttempt { email, password };
 
     match user {
-        Some(DashboardModel::User(user)) if user == login_attempt => {
+        Some(DashboardModel::User(u)) if u == login_attempt => {
             info!("dashboard login succeeded for {}", login_attempt.email);
-            let json = serde_json::to_vec(&user)?;
+
+            let token = jwt_generate(&login_attempt.email)?;
+            let json = serde_json::to_vec(&serde_json::json!({ "token": token }))?;
 
             Ok(Response::builder()
                 .status(StatusCode::OK)

--- a/backend/src/api/login.rs
+++ b/backend/src/api/login.rs
@@ -4,7 +4,7 @@ use http::StatusCode;
 use log::{error, info, warn};
 use std::error::Error;
 
-use crate::{PlatformModel, PlatformStore};
+use crate::{generate as jwt_generate, PlatformModel, PlatformStore};
 use models::LoginAttempt;
 
 /// Authenticate a platform user.
@@ -46,9 +46,11 @@ pub fn login_route(
     };
 
     match user {
-        Some(PlatformModel::User(user)) if user == login_attempt => {
+        Some(PlatformModel::User(u)) if u == login_attempt => {
             info!("user {email} authenticated successfully");
-            let json = serde_json::to_vec(&user)?;
+
+            let token = jwt_generate(&email)?;
+            let json = serde_json::to_vec(&serde_json::json!({ "token": token }))?;
 
             Ok(Response::builder()
                 .status(StatusCode::OK)

--- a/backend/tests/routes.rs
+++ b/backend/tests/routes.rs
@@ -71,6 +71,9 @@ fn login_route_success() {
     )
     .unwrap();
     assert_eq!(res.status(), StatusCode::OK);
+    let body = res.body();
+    let v: serde_json::Value = serde_json::from_slice(body).unwrap();
+    assert!(v.get("token").is_some());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- update login and dashboard login endpoints to issue JWTs
- update tests to verify token generation

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688a7cd71a0c832babdf2387cf76ddbc