### PR TITLE
Add token support in frontend client context

### DIFF
--- a/frontend/src/bin/frontend.rs
+++ b/frontend/src/bin/frontend.rs
@@ -18,6 +18,7 @@ fn App() -> Element {
 
     use_context_provider(|| Signal::new(ClientContext {
         client: Client::new(),
+        token: None,
     }));
 
     use_context_provider(|| Signal::new(BrandContext {

--- a/frontend/src/context/client.rs
+++ b/frontend/src/context/client.rs
@@ -3,4 +3,11 @@ use reqwest::Client;
 #[derive(Clone)]
 pub struct ClientContext {
   pub client: Client,
+  pub token: Option<String>,
+}
+
+impl ClientContext {
+    pub fn set_token(&mut self, token: String) {
+        self.token = Some(token);
+    }
 }


### PR DESCRIPTION
## Summary
- expand `ClientContext` with a token and add `set_token`
- initialize the context with `token: None` in the frontend binary

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688a7f7a8ab4832ba8e31e41425e1e7a