### PR TITLE
Add JWT auth docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ models/    - shared data models
 log4rs.yml - logging configuration
 ```
 
+See `backend/README.md` for backend usage and authentication details.
+
 The backend stores its data under the `data/` directory (ignored in Git). It
 creates the following sub directories at runtime:
 
@@ -61,3 +63,9 @@ dx serve --package frontend
 ```
 
 The frontend communicates with the backend over HTTP at `http://localhost:8080`.
+
+## Authentication
+
+The backend uses JSON Web Tokens (JWT) for all API requests. Set the `JWT_SECRET` environment variable to configure the signing key; it defaults to `secret` if unset.
+
+`POST /platform/login` and `POST /dashboard/login` now return a JSON object containing a `token` field. Use this token in subsequent requests by including an `Authorization: Bearer <token>` header.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,28 @@
+# Backend Service
+
+This crate exposes an HTTP API for managing tournament data. It requires a signing key for issuing JSON Web Tokens.
+
+## Environment
+
+Set `JWT_SECRET` to your desired secret key before running the service:
+
+```bash
+export JWT_SECRET=mysecret
+cargo run -p backend --bin backend
+```
+
+If unset, the server defaults to `secret`.
+
+## Authentication flow
+
+Call `POST /platform/login` or `POST /dashboard/login` with valid credentials. The response body contains a `token` field:
+
+```json
+{ "token": "<jwt>" }
+```
+
+Include this token in the `Authorization` header when calling other endpoints:
+
+```
+Authorization: Bearer <jwt>
+```


### PR DESCRIPTION
## Summary
- explain how the backend uses JWT tokens and JWT_SECRET
- document login responses returning a token and how to use it
- add backend README with auth details

## Testing
- `cargo test --workspace` *(fails: `cargo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a820ab274832b9535c6ea1fa10285