### PR TITLE
Add token handling in frontend

### DIFF
--- a/frontend/src/hooks/use_dashboard_api.rs
+++ b/frontend/src/hooks/use_dashboard_api.rs
@@ -14,12 +14,17 @@ pub fn use_dashboard_api(
   client: Signal<ClientContext>,
 ) -> Resource<Option<DashboardView>> {
     use_resource(move || async move {
-      let result = client().client.clone().get(
+      let ctx = client();
+      let mut req = ctx.client.clone().get(
           "http://localhost:8000/dashboard",
         ).header(
           "x-tenant_id",
           "bucket-golf",
-        ).send().await;
+        );
+      if let Some(token) = &ctx.token {
+          req = req.bearer_auth(token);
+      }
+      let result = req.send().await;
 
       let parsed = match result {
         Ok(response) => {

--- a/frontend/src/hooks/use_event.rs
+++ b/frontend/src/hooks/use_event.rs
@@ -13,12 +13,17 @@ pub fn use_event(
     use_resource(move || {
       let id = id.clone();
       async move {
-        let result = client().client.clone().get(
+        let ctx = client();
+        let mut req = ctx.client.clone().get(
             "http://localhost:8000/dashboard/event",
           ).header(
             "x-id",
             id,
-          ).send().await;
+          );
+        if let Some(token) = &ctx.token {
+            req = req.bearer_auth(token);
+        }
+        let result = req.send().await;
 
         let parsed = match result {
           Ok(response) => {

--- a/frontend/src/hooks/use_platform_login.rs
+++ b/frontend/src/hooks/use_platform_login.rs
@@ -1,14 +1,20 @@
 use crate::{ClientContext, ToastContext, ToastKind, ToastMessage};
 use dioxus::prelude::*;
 use models::LoginAttempt;
+use serde::Deserialize;
+#[cfg(target_arch = "wasm32")]
+use web_sys::window;
 
-use models::PlatformUser;
+#[derive(Deserialize)]
+struct TokenResponse {
+    token: String,
+}
 
 pub fn use_platform_login(
     login: Signal<Option<LoginAttempt>>,
     mut toast: Signal<ToastContext>,
-    client: Signal<ClientContext>,
-) -> Resource<Option<PlatformUser>> {
+    mut client: Signal<ClientContext>,
+) -> Resource<Option<String>> {
     use_resource(move || async move{
       let login = login.read();
         let login2 = match &*(login) {
@@ -16,10 +22,10 @@ pub fn use_platform_login(
             _ => return None, // If login is None, we return None immediately
             //None => return None,
         };
-        let client = client();
+        let mut client_ctx = client.write();
         let mut toast = toast.write();
 
-        let result = client
+        let result = client_ctx
             .client
             .get("http://localhost:8000/platform/login")
             .header("x-email", login2.email.clone())
@@ -28,12 +34,21 @@ pub fn use_platform_login(
             .await;
 
         let parsed = match result {
-            Ok(response) => response.json::<PlatformUser>().await,
+            Ok(response) => response.json::<TokenResponse>().await,
             Err(e) => Err(e),
         };
 
         match parsed {
-            Ok(user) => Some(user),
+            Ok(token) => {
+                client_ctx.set_token(token.token.clone());
+                #[cfg(target_arch = "wasm32")]
+                if let Some(win) = window() {
+                    if let Ok(Some(storage)) = win.local_storage() {
+                        let _ = storage.set_item("token", &token.token);
+                    }
+                }
+                Some(token.token)
+            }
             Err(_) => {
                 toast.toast = Some(ToastMessage {
                     message: "Login failed".to_string(),

--- a/frontend/src/hooks/use_register_event.rs
+++ b/frontend/src/hooks/use_register_event.rs
@@ -11,13 +11,16 @@ pub fn use_register_event(
         let Some((event_id, email)) = &*trigger.read() else {
             return None;
         };
-        let result = client()
+        let ctx = client();
+        let mut req = ctx
             .client
             .post("http://localhost:8000/dashboard/register_event")
             .header("x-id", event_id.clone())
-            .header("x-email", email.clone())
-            .send()
-            .await;
+            .header("x-email", email.clone());
+        if let Some(token) = &ctx.token {
+            req = req.bearer_auth(token);
+        }
+        let result = req.send().await;
         let parsed = match result {
             Ok(resp) => resp.json::<Registration>().await,
             Err(e) => Err(e),


### PR DESCRIPTION
## Summary
- parse login responses as `{ token: String }`
- store token in `ClientContext` and localStorage
- send bearer token with API requests when available

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_688a82063fd0832bb6b7a2de30fae87d