### PR TITLE
Fix frontend build for wasm32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,6 +1637,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "web-sys",
 ]
 
 [[package]]

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -10,6 +10,7 @@ dioxus = { version = "0.6.0", features = ["router"] }
 reqwest = { version = "0.12.15", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+web-sys = { version = "0.3", features = ["Window", "Storage"] }
 
 
 [features]


### PR DESCRIPTION
## Summary
- add `web-sys` dependency so localStorage is available

## Testing
- `cargo check -p frontend --target wasm32-unknown-unknown`

------
https://chatgpt.com/codex/tasks/task_e_688bd9405624832b80cc76841aea5c5a