### PR TITLE
Add GitHub CI for cargo checks

### DIFF
--- a/.github/workflows/cargo-check.yml
+++ b/.github/workflows/cargo-check.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  cargo-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+      - name: Add WebAssembly target
+        run: rustup target add wasm32-unknown-unknown
+      - name: cargo check
+        run: cargo check
+      - name: cargo check (frontend WASM)
+        run: cargo check --target wasm32-unknown-unknown --package frontend
+


### PR DESCRIPTION
## Summary
- add CI workflow running `cargo check`
- also run `cargo check --target wasm32-unknown-unknown --package frontend`

## Testing
- `cargo check`
- `cargo check --target wasm32-unknown-unknown --package frontend` *(fails: unresolved import `web_sys`)*

------
https://chatgpt.com/codex/tasks/task_e_688bd90c1764832b8fdfbed70d80538f