### PR TITLE
Add platform admin page with routing

### DIFF
--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -32,6 +32,7 @@ pub use pages::create_event::CreateEvent;
 pub use pages::event_details::EventDetails;
 pub use pages::event_register::RegisterEvent;
 pub use pages::profile::ProfilePage;
+pub use pages::platform_admin::PlatformAdmin;
 
 #[derive(Routable, Clone, PartialEq)]
 pub enum Route {
@@ -49,6 +50,8 @@ pub enum Route {
     ConfigurePlatform,
     #[route("/manage-platform")]
     ManagePlatform,
+    #[route("/platform-admin")]
+    PlatformAdmin,
     #[route("/dashboard")]
     Dashboard,
     #[route("/create-event")]

--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -48,6 +48,11 @@ pub fn DashboardLayout(name: String, announcement: String, events: Vec<Event>, a
                   "＋ Create Event"
                 }
               }
+              Link { to: Route::PlatformAdmin {},
+                button { style: "background: white; color: {secondary_color}; font-weight: 700; padding: 0.6rem 1.4rem; border-radius: 0.5rem; border: none; box-shadow: 0 2px 8px rgba(0,0,0,0.04); font-size: 1rem; transition: background 0.2s; cursor: pointer;",
+                  "Admin"
+                }
+              }
               NotificationsDropdown {}
               Link { to: Route::ProfilePage {},
                 span { style: "display: inline-block; width: 2.7rem; height: 2.7rem; border-radius: 9999px; background: linear-gradient(135deg, #e0e7ff 60%, {primary_color} 100%); overflow: hidden; text-align: center; line-height: 2.7rem; font-weight: 700; color: {secondary_color}; font-size: 1.2rem; border: 2px solid #fff; box-shadow: 0 2px 8px rgba(0,0,0,0.04);",

--- a/frontend/src/pages/homepage.rs
+++ b/frontend/src/pages/homepage.rs
@@ -53,6 +53,10 @@ pub fn Homepage() -> Element {
             onmouseover: |_| {},
             "Contact"
           }
+          Link { to: Route::PlatformAdmin {},
+            style: "text-decoration: none; color: inherit;",
+            "Admin"
+          }
         }
       }
 

--- a/frontend/src/pages/mod.rs
+++ b/frontend/src/pages/mod.rs
@@ -12,3 +12,4 @@ pub mod create_event;
 pub mod event_details;
 pub mod event_register;
 pub mod profile;
+pub mod platform_admin;

--- a/frontend/src/pages/platform_admin.rs
+++ b/frontend/src/pages/platform_admin.rs
@@ -1,0 +1,29 @@
+use dioxus::prelude::*;
+use crate::{BrandContext, Route};
+
+#[component]
+pub fn PlatformAdmin() -> Element {
+    let brand = use_context::<Signal<BrandContext>>();
+    let BrandContext { name, logo: _, primary_color: _, secondary_color } = brand.read().clone();
+
+    rsx! {
+        div { style: "min-height: 100vh; padding: 3rem 1rem; background-color: #f9fafb; font-family: sans-serif;",
+            div { style: "max-width: 40rem; margin: 0 auto; text-align: center;",
+                h1 { style: "font-size: 2rem; font-weight: bold; color: #111827; margin-bottom: 1rem;", "{name} Admin" }
+                p { style: "font-size: 1rem; color: #4b5563; margin-bottom: 2rem;", "Manage your community settings and events." }
+                div { style: "display: flex; flex-direction: column; gap: 1rem;",
+                    Link { to: Route::ManagePlatform {},
+                        button { style: button_style(), "Manage Platform" }
+                    }
+                    Link { to: Route::Dashboard {},
+                        button { style: button_style(), "View Dashboard" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn button_style() -> &'static str {
+    "background-color: #4f46e5; color: white; font-weight: 600; padding: 0.75rem 1.5rem; border: none; border-radius: 0.5rem; cursor: pointer;"
+}


### PR DESCRIPTION
## Summary
- implement `PlatformAdmin` page
- export new page and register `/platform-admin` route
- link to PlatformAdmin from homepage nav and dashboard header

## Testing
- `cargo check -p frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bdf6dc990832b9793035f881b709f