### PR TITLE
Update dashboard and event auth handling

### DIFF
--- a/backend/src/api/event_route.rs
+++ b/backend/src/api/event_route.rs
@@ -22,21 +22,17 @@ pub fn event_details_route(
         .and_then(|t| verify(t).ok())
         .is_some();
 
-    if !auth_ok {
-        return Ok(
-            Response::builder()
-                .status(StatusCode::UNAUTHORIZED)
-                .header("Content-Type", "application/json")
-                .body(b"{}".to_vec())?,
-        );
-    }
 
     info!("querying event {id}");
     let event = dashboard_store.borrow_inner().query_owned(id.clone())?;
 
     match event {
-        Some(crate::DashboardModel::Event(event)) => {
+        Some(crate::DashboardModel::Event(mut event)) => {
             info!("event {id} found");
+            if !auth_ok {
+                event.banner = None;
+                event.upsell = None;
+            }
             let json = serde_json::to_vec(&event)?;
 
             Ok(Response::builder()

--- a/backend/tests/routes.rs
+++ b/backend/tests/routes.rs
@@ -8,7 +8,7 @@ use backend::{
     DashboardCommand, DashboardStore, KVStore, PlatformCommand, PlatformModel,
     PlatformStore, RegistrationModel, RegistrationStore,
 };
-use models::Event;
+use models::{Event, DashboardView};
 use http::{Request, StatusCode};
 use models::{Platform, PlatformPatch, PlatformUser};
 use serde_json;
@@ -267,7 +267,9 @@ fn dashboard_route_success() {
 fn dashboard_route_unauthorized() {
     let store = temp_dashboard_store();
     let res = dashboard_route(&Request::default(), store, "t1".into()).unwrap();
-    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: DashboardView = serde_json::from_slice(res.body()).unwrap();
+    assert!(body.active_events.is_empty());
 }
 
 #[test]
@@ -300,5 +302,7 @@ fn event_details_route_success() {
 fn event_details_route_unauthorized() {
     let store = temp_dashboard_store();
     let res = event_details_route(&Request::default(), store, "e1".into()).unwrap();
-    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(res.status(), StatusCode::OK);
+    let event: Event = serde_json::from_slice(res.body()).unwrap();
+    assert!(event.banner.is_none() && event.upsell.is_none());
 }


### PR DESCRIPTION
## Summary
- return dashboard data when unauthenticated but hide active events
- return event details to all requests while hiding restricted fields
- update tests for new behaviour

## Testing
- `cargo test --all --quiet` *(fails: `bash: command not found: cargo`)*

------
https://chatgpt.com/codex/tasks/task_e_688bdf852fb4832b9ab6de9fe9426407