### PR TITLE
Add dashboard name hook and login redirect

### DIFF
--- a/frontend/src/hooks/mod.rs
+++ b/frontend/src/hooks/mod.rs
@@ -3,3 +3,4 @@ pub mod use_dashboard_login;
 pub mod use_event;
 pub mod use_platform_login;
 pub mod use_register_event;
+pub mod use_platform_name;

--- a/frontend/src/hooks/use_platform_name.rs
+++ b/frontend/src/hooks/use_platform_name.rs
@@ -1,0 +1,34 @@
+use dioxus::prelude::*;
+use crate::{ClientContext, ToastContext, ToastKind, ToastMessage};
+use models::DashboardView;
+
+pub fn use_platform_name(
+    mut toast: Signal<ToastContext>,
+    client: Signal<ClientContext>,
+) -> Resource<Option<String>> {
+    use_resource(move || async move {
+        let ctx = client();
+        let mut req = ctx
+            .client
+            .get("http://localhost:8000/dashboard")
+            .header("x-tenant_id", "bucket-golf");
+        if let Some(token) = &ctx.token {
+            req = req.bearer_auth(token);
+        }
+        let result = req.send().await;
+        let parsed = match result {
+            Ok(resp) => resp.json::<DashboardView>().await,
+            Err(e) => Err(e),
+        };
+        match parsed {
+            Ok(view) => Some(view.name),
+            Err(_) => {
+                toast.write().toast = Some(ToastMessage {
+                    message: "Failed to fetch /dashboard".to_string(),
+                    kind: ToastKind::Error,
+                });
+                None
+            }
+        }
+    })
+}

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -6,6 +6,7 @@ pub use hooks::use_event::use_event;
 pub use hooks::use_platform_login::use_platform_login;
 pub use hooks::use_register_event::use_register_event;
 pub use hooks::use_dashboard_login::use_dashboard_login;
+pub use hooks::use_platform_name::use_platform_name;
 
 pub mod components;
 pub use components::notifications::NotificationsDropdown;

--- a/frontend/src/pages/dashboard_login.rs
+++ b/frontend/src/pages/dashboard_login.rs
@@ -1,11 +1,23 @@
 use dioxus::prelude::*;
-use crate::{Route, BrandContext, use_dashboard_login, ClientContext, ToastContext};
-use models::{LoginAttempt};
+use dioxus_router::prelude::use_navigator;
+use crate::{
+    Route,
+    BrandContext,
+    use_dashboard_login,
+    use_platform_name,
+    ClientContext,
+    ToastContext,
+};
+use models::LoginAttempt;
 
 #[component]
 pub fn DashboardLogin() -> Element {
   let brand = use_context::<Signal<BrandContext>>();
-  let BrandContext {name, logo: _, primary_color: _, secondary_color} = brand.read().clone();
+  let BrandContext {name: _, logo: _, primary_color: _, secondary_color} = brand.read().clone();
+  let platform_name = use_platform_name(
+    use_context::<Signal<ToastContext>>(),
+    use_context::<Signal<ClientContext>>(),
+  );
   let mut email = use_signal(|| String::new());
   let mut password = use_signal(|| String::new());
   let mut login_attempt = use_signal(|| None);
@@ -17,12 +29,18 @@ pub fn DashboardLogin() -> Element {
     use_context::<Signal<ClientContext>>(),
   );
   println!("User: {:?}", user.read());
+  let navigator = use_navigator();
+  use_effect(move || {
+    if user.read().is_some() {
+      navigator.push(Route::Dashboard {});
+    }
+  });
 
   rsx!(
     div { style: "min-height: 100vh; display: flex; align-items: center; justify-content: center; background-color: #f9fafb; font-family: sans-serif;",
       div { style: "width: 100%; max-width: 24rem; background: white; padding: 2rem; border-radius: 0.5rem; box-shadow: 0 4px 6px rgba(0,0,0,0.1);",
         h2 { style: "text-align: center; font-size: 1.5rem; font-weight: bold; margin-bottom: 1rem; color: #111827;",
-          "Sign in to {name}"
+          "Sign in to {platform_name.read().as_deref().unwrap_or("")}"
         }
         div { style: "display: flex; flex-direction: column; gap: 1rem;",
           div {


### PR DESCRIPTION
## Summary
- add `use_platform_name` hook for retrieving the dashboard name
- export and register the hook
- load platform name in `DashboardLogin` page
- redirect to dashboard after successful login

## Testing
- `cargo check` *(fails: `cargo` not found)*
- `cargo test` *(fails: `cargo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688beca2c2fc832bbc4e79069089e55d