### PR TITLE
Add dashboard profile API and hook

### DIFF
--- a/backend/src/api/dashboard_profile_route.rs
+++ b/backend/src/api/dashboard_profile_route.rs
@@ -1,0 +1,85 @@
+use http::{Request, Response, StatusCode};
+use std::error::Error;
+
+use crate::{verify, not_found_route, DashboardStore, DashboardModel, DashboardCommand};
+use log::{info, warn};
+use models::DashboardUserPatch;
+
+/// Fetch the authenticated user's dashboard profile.
+pub fn dashboard_profile_get_route(
+    req: &Request<()>,
+    dashboard_store: DashboardStore,
+) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+    let claims = req
+        .headers()
+        .get("Authorization")
+        .and_then(|h| h.to_str().ok())
+        .map(|h| h.strip_prefix("Bearer ").unwrap_or(h))
+        .and_then(|t| verify(t).ok());
+
+    let Some(claims) = claims else {
+        return Ok(
+            Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .header("Content-Type", "application/json")
+                .body(b"{}".to_vec())?,
+        );
+    };
+
+    let key = format!("user-{}", claims.sub);
+    info!("loading profile for {}", claims.sub);
+    let model = dashboard_store.borrow_inner().query_owned(key.clone())?;
+    match model {
+        Some(DashboardModel::User(user)) => {
+            let json = serde_json::to_vec(&user)?;
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
+                .body(json)?)
+        }
+        _ => {
+            warn!("profile not found for {}", claims.sub);
+            not_found_route()
+        }
+    }
+}
+
+/// Update the authenticated user's profile using the provided password.
+pub fn dashboard_profile_patch_route(
+    req: &Request<()>,
+    mut dashboard_store: DashboardStore,
+    password: String,
+) -> Result<Response<Vec<u8>>, Box<dyn Error>> {
+    let claims = req
+        .headers()
+        .get("Authorization")
+        .and_then(|h| h.to_str().ok())
+        .map(|h| h.strip_prefix("Bearer ").unwrap_or(h))
+        .and_then(|t| verify(t).ok());
+
+    let Some(claims) = claims else {
+        return Ok(
+            Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .header("Content-Type", "application/json")
+                .body(b"{}".to_vec())?,
+        );
+    };
+
+    info!("updating profile for {}", claims.sub);
+    let patch = DashboardUserPatch {
+        password: if password.is_empty() { None } else { Some(password) },
+    };
+    dashboard_store.command(&DashboardCommand::UpdateUser((claims.sub.clone(), patch)))?;
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "application/json")
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "*")
+        .header("Access-Control-Allow-Headers", "*")
+        .body(b"{\"status\":\"updated\"}".to_vec())?)
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -6,3 +6,4 @@ pub mod login;
 pub mod register_event_route;
 pub mod platform_create_route;
 pub mod platform_update_route;
+pub mod dashboard_profile_route;

--- a/backend/src/bin/backend.rs
+++ b/backend/src/bin/backend.rs
@@ -17,6 +17,8 @@ use backend::{
   dashboard_login_route,
   platform_create_route,
   platform_update_route,
+  dashboard_profile_get_route,
+  dashboard_profile_patch_route,
 };
 fn clear_directory(path: &str) -> io::Result<()> {
     if Path::new(path).exists() {
@@ -190,6 +192,23 @@ pub fn main() -> Result<(), Box<dyn Error>> {
                     .and_then(|v| v.to_str().ok()).unwrap_or_default()
                     .to_string(),
                 ),
+                "/dashboard/profile" => match request.method() {
+                    &http::Method::GET => dashboard_profile_get_route(
+                        &request,
+                        dashboard_store.clone(),
+                    ),
+                    &http::Method::PATCH => dashboard_profile_patch_route(
+                        &request,
+                        dashboard_store.clone(),
+                        request
+                            .headers()
+                            .get("x-password")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or_default()
+                            .to_string(),
+                    ),
+                    _ => not_found_route(),
+                },
                 "/platform/login" => login_route(
                     &request,
                     platform_store.clone(),

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -27,6 +27,9 @@ pub use crate::api::login::login_route;
 pub use crate::api::register_event_route::register_event_route;
 pub use crate::api::platform_create_route::platform_create_route;
 pub use crate::api::platform_update_route::platform_update_route;
+pub use crate::api::dashboard_profile_route::{
+    dashboard_profile_get_route, dashboard_profile_patch_route,
+};
 
 pub mod database;
 pub use crate::database::cqrs_store::{CQRSStore, Command};

--- a/frontend/src/hooks/mod.rs
+++ b/frontend/src/hooks/mod.rs
@@ -3,3 +3,4 @@ pub mod use_dashboard_login;
 pub mod use_event;
 pub mod use_platform_login;
 pub mod use_register_event;
+pub mod use_profile;

--- a/frontend/src/hooks/use_profile.rs
+++ b/frontend/src/hooks/use_profile.rs
@@ -1,0 +1,50 @@
+use dioxus::prelude::*;
+use crate::{ClientContext, ToastContext, ToastKind, ToastMessage};
+use models::DashboardUser;
+
+/// Load the profile for the authenticated dashboard user and optionally update the password when triggered.
+pub fn use_profile(
+    trigger: Signal<Option<String>>, 
+    mut toast: Signal<ToastContext>,
+    client: Signal<ClientContext>,
+) -> Resource<Option<DashboardUser>> {
+    // Update when trigger is set
+    use_future(move || async move {
+        let Some(pass) = &*trigger.read() else { return; };
+        let ctx = client();
+        let mut req = ctx
+            .client
+            .patch("http://localhost:8000/dashboard/profile")
+            .header("x-password", pass.clone());
+        if let Some(token) = &ctx.token {
+            req = req.bearer_auth(token);
+        }
+        let _ = req.send().await;
+    });
+
+    // Fetch profile
+    use_resource(move || async move {
+        let ctx = client();
+        let mut req = ctx
+            .client
+            .get("http://localhost:8000/dashboard/profile");
+        if let Some(token) = &ctx.token {
+            req = req.bearer_auth(token);
+        }
+        let result = req.send().await;
+        let parsed = match result {
+            Ok(resp) => resp.json::<DashboardUser>().await,
+            Err(e) => Err(e),
+        };
+        match parsed {
+            Ok(user) => Some(user),
+            Err(_) => {
+                toast.write().toast = Some(ToastMessage {
+                    message: "Failed to fetch /dashboard/profile".to_string(),
+                    kind: ToastKind::Error,
+                });
+                None
+            }
+        }
+    })
+}

--- a/frontend/src/pages/profile.rs
+++ b/frontend/src/pages/profile.rs
@@ -1,7 +1,20 @@
 use dioxus::prelude::*;
+use crate::{hooks::use_profile::use_profile, ClientContext, ToastContext};
 
 #[component]
 pub fn ProfilePage() -> Element {
+  let toast = use_context::<Signal<ToastContext>>();
+  let client = use_context::<Signal<ClientContext>>();
+  let mut password = use_signal(|| String::new());
+  let mut trigger = use_signal(|| None::<String>);
+  let profile = use_profile(trigger, toast, client);
+  let email = profile
+      .read()
+      .as_ref()
+      .and_then(|p| p.as_ref())
+      .map(|p| p.email.clone())
+      .unwrap_or_default();
+
   rsx!(
     div {
       style: "
@@ -40,8 +53,8 @@ pub fn ProfilePage() -> Element {
             style: "width: 8rem; height: 8rem; border-radius: 9999px; object-fit: cover; border: 2px solid #e5e7eb; margin-bottom: 1rem;"
           },
 
-          h2 { style: "font-size: 1.25rem; font-weight: 600; color: #111827;", "Jane Doe" },
-          p { style: "font-size: 0.875rem; color: #6b7280;", "janedoe@example.com" },
+          h2 { style: "font-size: 1.25rem; font-weight: 600; color: #111827;", "{email}" },
+          p { style: "font-size: 0.875rem; color: #6b7280;", "{email}" },
 
           // Stats
           div {
@@ -72,10 +85,11 @@ pub fn ProfilePage() -> Element {
           form {
             style: "display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 2rem;",
 
-            input { placeholder: "Full Name", value: "Jane Doe", style: base_input() }
-            input { r#type: "email", placeholder: "Email", value: "janedoe@example.com", style: base_input() }
+            input { placeholder: "Full Name", value: "", style: base_input() }
+            input { r#type: "email", placeholder: "Email", value: "{email}", style: base_input() }
             input { placeholder: "Phone", value: "123-456-7890", style: base_input() }
             input { r#type: "url", placeholder: "Profile Picture URL", style: base_input() }
+            input { r#type: "password", placeholder: "New Password", oninput: move |e| password.set(e.value()), value: password.clone(), style: base_input() }
           }
 
           h2 { style: "font-size: 1.25rem; font-weight: 600; margin: 2rem 0 1rem;", "Billing Address" },
@@ -104,6 +118,7 @@ pub fn ProfilePage() -> Element {
               border: none;
               cursor: pointer;
             ",
+            onclick: move |_| trigger.set(Some(password())),
             "Update Profile"
           }
         }


### PR DESCRIPTION
## Summary
- add `dashboard_profile_*` API routes for profile retrieval and update
- wire new profile routes into backend server and expose from crate
- create `use_profile` hook for frontend
- update Profile page to fetch and update profile info

## Testing
- `cargo test --quiet` *(fails: dashboard_route_unauthorized, event_details_route_unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_688becaada44832b8aec3329a456cdc1