### PR TITLE
Add CORS headers on all error responses

### DIFF
--- a/backend/src/api/dashboard_profile_route.rs
+++ b/backend/src/api/dashboard_profile_route.rs
@@ -22,6 +22,9 @@ pub fn dashboard_profile_get_route(
             Response::builder()
                 .status(StatusCode::UNAUTHORIZED)
                 .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
                 .body(b"{}".to_vec())?,
         );
     };
@@ -65,6 +68,9 @@ pub fn dashboard_profile_patch_route(
             Response::builder()
                 .status(StatusCode::UNAUTHORIZED)
                 .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
                 .body(b"{}".to_vec())?,
         );
     };

--- a/backend/src/api/login.rs
+++ b/backend/src/api/login.rs
@@ -67,7 +67,6 @@ pub fn login_route(
         }
         _ => {
             warn!("invalid login for {email}");
-<<<<<<< HEAD
             Ok(
                 Response::builder()
                     .status(StatusCode::UNAUTHORIZED)
@@ -77,15 +76,6 @@ pub fn login_route(
                     .header("Access-Control-Allow-Headers", "*")
                     .body(b"{}".to_vec())?,
             )
-=======
-            Ok(Response::builder()
-                .status(StatusCode::UNAUTHORIZED)
-                .header("Content-Type", "application/json")
-                .header("Access-Control-Allow-Origin", "*")
-                .header("Access-Control-Allow-Methods", "*")
-                .header("Access-Control-Allow-Headers", "*")
-                .body(b"{}".to_vec())?)
->>>>>>> origin/main
         }
     }
 }

--- a/backend/src/api/login.rs
+++ b/backend/src/api/login.rs
@@ -24,9 +24,14 @@ pub fn login_route(
 
     if email.trim().is_empty() || password.trim().is_empty() {
         warn!("login request missing credentials");
-        return Ok(Response::builder()
-            .status(StatusCode::BAD_REQUEST)
-            .body(b"{}".to_vec())?);
+        return Ok(
+            Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
+                .body(b"{}".to_vec())?,
+        );
     }
 
     let user = match platform_store
@@ -62,10 +67,15 @@ pub fn login_route(
         }
         _ => {
             warn!("invalid login for {email}");
-            Ok(Response::builder()
-                .status(StatusCode::UNAUTHORIZED)
-                .header("Content-Type", "application/json")
-                .body(b"{}".to_vec())?)
+            Ok(
+                Response::builder()
+                    .status(StatusCode::UNAUTHORIZED)
+                    .header("Content-Type", "application/json")
+                    .header("Access-Control-Allow-Origin", "*")
+                    .header("Access-Control-Allow-Methods", "*")
+                    .header("Access-Control-Allow-Headers", "*")
+                    .body(b"{}".to_vec())?,
+            )
         }
     }
 }

--- a/backend/src/api/platform_create_route.rs
+++ b/backend/src/api/platform_create_route.rs
@@ -25,6 +25,9 @@ pub fn platform_create_route(
             Response::builder()
                 .status(StatusCode::UNAUTHORIZED)
                 .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
                 .body(b"{}".to_vec())?,
         );
     }

--- a/backend/src/api/platform_get_route.rs
+++ b/backend/src/api/platform_get_route.rs
@@ -19,10 +19,15 @@ pub fn platform_get_route(
         .is_some();
 
     if !auth_ok {
-        return Ok(Response::builder()
-            .status(StatusCode::UNAUTHORIZED)
-            .header("Content-Type", "application/json")
-            .body(b"{}".to_vec())?);
+        return Ok(
+            Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
+                .body(b"{}".to_vec())?,
+        );
     }
 
     info!("loading platform {tenant_id}");

--- a/backend/src/api/platform_update_route.rs
+++ b/backend/src/api/platform_update_route.rs
@@ -25,6 +25,9 @@ pub fn platform_update_route(
             Response::builder()
                 .status(StatusCode::UNAUTHORIZED)
                 .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
                 .body(b"{}".to_vec())?,
         );
     }

--- a/backend/src/api/register_event_route.rs
+++ b/backend/src/api/register_event_route.rs
@@ -26,6 +26,9 @@ pub fn register_event_route(
             Response::builder()
                 .status(StatusCode::UNAUTHORIZED)
                 .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
                 .body(b"{}".to_vec())?,
         );
     }
@@ -33,10 +36,15 @@ pub fn register_event_route(
 
     if event_id.trim().is_empty() || email.trim().is_empty() {
         warn!("invalid registration parameters");
-        return Ok(Response::builder()
-            .status(StatusCode::BAD_REQUEST)
-            .header("Content-Type", "application/json")
-            .body(b"{}".to_vec())?);
+        return Ok(
+            Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
+                .body(b"{}".to_vec())?,
+        );
     }
 
     let registration = Registration {
@@ -49,9 +57,14 @@ pub fn register_event_route(
         registration.clone(),
     )) {
         error!("failed to create registration: {e}");
-        return Ok(Response::builder()
-            .status(StatusCode::INTERNAL_SERVER_ERROR)
-            .body(b"{}".to_vec())?);
+        return Ok(
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "*")
+                .header("Access-Control-Allow-Headers", "*")
+                .body(b"{}".to_vec())?,
+        );
     }
 
     let json = serde_json::to_vec(&registration)?;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -16,7 +16,9 @@ pub use crate::futures::AsyncWriteAllFuture;
 mod utils;
 pub use crate::utils::channel::{channel, Receiver, Sender};
 pub use crate::utils::error::GenericError;
-pub use crate::utils::responses::{error_route, not_found_route, serve_route};
+pub use crate::utils::responses::{
+    error_route, not_found_route, preflight_route, serve_route,
+};
 
 pub mod api;
 pub use crate::api::dashboard_route::dashboard_route;

--- a/backend/src/utils/responses.rs
+++ b/backend/src/utils/responses.rs
@@ -43,3 +43,17 @@ pub fn error_route() -> Response<Vec<u8>> {
             Response::new(Vec::new())
         })
 }
+
+/// Response to HTTP CORS preflight `OPTIONS` requests.
+pub fn preflight_route() -> Response<Vec<u8>> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "*")
+        .header("Access-Control-Allow-Headers", "*")
+        .body(Vec::new())
+        .unwrap_or_else(|e| {
+            error!("failed to build preflight response: {e}");
+            Response::new(Vec::new())
+        })
+}

--- a/backend/src/utils/responses.rs
+++ b/backend/src/utils/responses.rs
@@ -34,6 +34,9 @@ pub fn error_route() -> Response<Vec<u8>> {
     Response::builder()
         .status(StatusCode::INTERNAL_SERVER_ERROR)
         .header("Content-Type", "text/html")
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Methods", "*")
+        .header("Access-Control-Allow-Headers", "*")
         .body("500 Internal Server Error".into())
         .unwrap_or_else(|e| {
             error!("failed to build error response: {e}");


### PR DESCRIPTION
## Summary
- apply CORS headers to unauthorized and other error paths
- include headers in `error_route`
- keep success responses consistent

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688bfd29675c832b90bbfdca2057d38d